### PR TITLE
Handle missing config keys during checkpoint search

### DIFF
--- a/langgraph/checkpoint/redis/__init__.py
+++ b/langgraph/checkpoint/redis/__init__.py
@@ -258,19 +258,14 @@ class RedisSaver(BaseRedisSaver[Redis, SearchIndex]):
             Optional[CheckpointTuple]: The retrieved checkpoint tuple, or None if no matching checkpoint was found.
         """
         thread_id = config["configurable"]["thread_id"]
-        checkpoint_id = str(get_checkpoint_id(config))
+        checkpoint_id = get_checkpoint_id(config)
         checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
 
+        checkpoint_filter_expression = Tag("thread_id") == thread_id
         if checkpoint_id:
-            checkpoint_filter_expression = (
-                (Tag("thread_id") == thread_id)
-                & (Tag("checkpoint_ns") == checkpoint_ns)
-                & (Tag("checkpoint_id") == checkpoint_id)
-            )
-        else:
-            checkpoint_filter_expression = (Tag("thread_id") == thread_id) & (
-                Tag("checkpoint_ns") == checkpoint_ns
-            )
+            checkpoint_filter_expression &= Tag("checkpoint_id") == str(checkpoint_id)
+        if checkpoint_ns:
+            checkpoint_filter_expression &= Tag("checkpoint_ns") == checkpoint_ns
 
         # Construct the query
         checkpoints_query = FilterQuery(

--- a/langgraph/checkpoint/redis/aio.py
+++ b/langgraph/checkpoint/redis/aio.py
@@ -132,16 +132,11 @@ class AsyncRedisSaver(BaseRedisSaver[AsyncRedis, AsyncSearchIndex]):
         checkpoint_id = get_checkpoint_id(config)
         checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
 
+        checkpoint_filter_expression = Tag("thread_id") == thread_id
         if checkpoint_id:
-            checkpoint_filter_expression = (
-                (Tag("thread_id") == thread_id)
-                & (Tag("checkpoint_ns") == checkpoint_ns)
-                & (Tag("checkpoint_id") == checkpoint_id)
-            )
-        else:
-            checkpoint_filter_expression = (Tag("thread_id") == thread_id) & (
-                Tag("checkpoint_ns") == checkpoint_ns
-            )
+            checkpoint_filter_expression &= Tag("checkpoint_id") == str(checkpoint_id)
+        if checkpoint_ns:
+            checkpoint_filter_expression &= Tag("checkpoint_ns") == checkpoint_ns
 
         # Construct the query
         checkpoints_query = FilterQuery(

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -592,3 +592,65 @@ async def test_async_redis_checkpointer(
         checkpoints = [c async for c in checkpointer.alist(config)]
         assert len(checkpoints) > 0
         assert checkpoints[-1].checkpoint["id"] == latest["id"]
+
+
+@pytest.mark.requires_api_keys
+@pytest.mark.asyncio
+async def test_root_graph_checkpoint(
+    redis_url: str, tools: List[BaseTool], model: ChatOpenAI
+) -> None:
+    """
+    A regression test for a bug where queries for checkpoints from the
+    root graph were failing to find valid checkpoints. When called from
+    a root graph, the `checkpoint_id` and `checkpoint_ns` keys are not
+    in the config object.
+    """
+
+    async with AsyncRedisSaver.from_conn_string(redis_url) as checkpointer:
+        await checkpointer.asetup()
+        # Create agent with checkpointer
+        graph = create_react_agent(model, tools=tools, checkpointer=checkpointer)
+
+        # Test initial query
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": "test1",
+                "checkpoint_ns": "",
+                "checkpoint_id": "",
+            }
+        }
+        res = await graph.ainvoke(
+            {"messages": [("human", "what's the weather in sf")]}, config
+        )
+
+        assert res is not None
+
+        # Test checkpoint retrieval
+        latest = await checkpointer.aget(config)
+
+        assert latest is not None
+        assert all(
+            k in latest
+            for k in [
+                "v",
+                "ts",
+                "id",
+                "channel_values",
+                "channel_versions",
+                "versions_seen",
+            ]
+        )
+        assert "messages" in latest["channel_values"]
+        assert (
+            len(latest["channel_values"]["messages"]) == 4
+        )  # Initial + LLM + Tool + Final
+
+        # Test checkpoint tuple
+        tuple_result = await checkpointer.aget_tuple(config)
+        assert tuple_result is not None
+        assert tuple_result.checkpoint == latest
+
+        # Test listing checkpoints
+        checkpoints = [c async for c in checkpointer.alist(config)]
+        assert len(checkpoints) > 0
+        assert checkpoints[-1].checkpoint["id"] == latest["id"]

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -486,3 +486,61 @@ def test_sync_redis_checkpointer(
         checkpoints = list(checkpointer.list(config))
         assert len(checkpoints) > 0
         assert checkpoints[-1].checkpoint["id"] == latest["id"]
+
+
+@pytest.mark.requires_api_keys
+def test_root_graph_checkpoint(
+    tools: list[BaseTool], model: ChatOpenAI, redis_url: str
+) -> None:
+    """
+    A regression test for a bug where queries for checkpoints from the
+    root graph were failing to find valid checkpoints. When called from
+    a root graph, the `checkpoint_id` and `checkpoint_ns` keys are not
+    in the config object.
+    """
+    with RedisSaver.from_conn_string(redis_url) as checkpointer:
+        checkpointer.setup()
+        # Create agent with checkpointer
+        graph = create_react_agent(model, tools=tools, checkpointer=checkpointer)
+
+        # Test initial query
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": "test1",
+            }
+        }
+        res = graph.invoke(
+            {"messages": [("human", "what's the weather in sf")]}, config
+        )
+
+        assert res is not None
+
+        # Test checkpoint retrieval
+        latest = checkpointer.get(config)
+
+        assert latest is not None
+        assert all(
+            k in latest
+            for k in [
+                "v",
+                "ts",
+                "id",
+                "channel_values",
+                "channel_versions",
+                "versions_seen",
+            ]
+        )
+        assert "messages" in latest["channel_values"]
+        assert (
+            len(latest["channel_values"]["messages"]) == 4
+        )  # Initial + LLM + Tool + Final
+
+        # Test checkpoint tuple
+        tuple_result = checkpointer.get_tuple(config)
+        assert tuple_result is not None
+        assert tuple_result.checkpoint == latest
+
+        # Test listing checkpoints
+        checkpoints = list(checkpointer.list(config))
+        assert len(checkpoints) > 0
+        assert checkpoints[-1].checkpoint["id"] == latest["id"]


### PR DESCRIPTION
When queried for checkpoints of a root graph, the `config` object the checkpointer receives will not have a `checkpoint_id` or `checkpoint_ns` key. Currently, we reinterpret their absence as presence but with either an empty string or the string "None", neither of which will find anything when queried. One because we aren't saving the string "None," and the other because this index doesn't support querying for empty strings on these fields (would need the INDEXEMPTY option on fields, which RedisVL doesn't currently support and only recent versions of RediSearch support).

This commit doesn't entirely solve the problem, however. Now, we are searching for any checkpoint for the thread, not checkpoints for the thread for the root graph. We need to store a sentinel value like "__empty__" and then query for it when the keys are not present in config.