### PR TITLE
Update all schemas to use the key_separator

### DIFF
--- a/langgraph/checkpoint/redis/ashallow.py
+++ b/langgraph/checkpoint/redis/ashallow.py
@@ -38,7 +38,8 @@ SCHEMAS = [
     {
         "index": {
             "name": "checkpoints",
-            "prefix": CHECKPOINT_PREFIX + REDIS_KEY_SEPARATOR,
+            "prefix": CHECKPOINT_PREFIX,
+            "key_separator": REDIS_KEY_SEPARATOR,
             "storage_type": "json",
         },
         "fields": [
@@ -51,7 +52,8 @@ SCHEMAS = [
     {
         "index": {
             "name": "checkpoints_blobs",
-            "prefix": CHECKPOINT_BLOB_PREFIX + REDIS_KEY_SEPARATOR,
+            "prefix": CHECKPOINT_BLOB_PREFIX,
+            "key_separator": REDIS_KEY_SEPARATOR,
             "storage_type": "json",
         },
         "fields": [
@@ -64,7 +66,8 @@ SCHEMAS = [
     {
         "index": {
             "name": "checkpoint_writes",
-            "prefix": CHECKPOINT_WRITE_PREFIX + REDIS_KEY_SEPARATOR,
+            "prefix": CHECKPOINT_WRITE_PREFIX,
+            "key_separator": REDIS_KEY_SEPARATOR,
             "storage_type": "json",
         },
         "fields": [

--- a/langgraph/checkpoint/redis/base.py
+++ b/langgraph/checkpoint/redis/base.py
@@ -36,7 +36,8 @@ SCHEMAS = [
     {
         "index": {
             "name": "checkpoints",
-            "prefix": CHECKPOINT_PREFIX + REDIS_KEY_SEPARATOR,
+            "prefix": CHECKPOINT_PREFIX,
+            "key_separator": REDIS_KEY_SEPARATOR,
             "storage_type": "json",
         },
         "fields": [
@@ -51,7 +52,8 @@ SCHEMAS = [
     {
         "index": {
             "name": "checkpoints_blobs",
-            "prefix": CHECKPOINT_BLOB_PREFIX + REDIS_KEY_SEPARATOR,
+            "prefix": CHECKPOINT_BLOB_PREFIX,
+            "key_separator": REDIS_KEY_SEPARATOR,
             "storage_type": "json",
         },
         "fields": [
@@ -65,7 +67,8 @@ SCHEMAS = [
     {
         "index": {
             "name": "checkpoint_writes",
-            "prefix": CHECKPOINT_WRITE_PREFIX + REDIS_KEY_SEPARATOR,
+            "prefix": CHECKPOINT_WRITE_PREFIX,
+            "key_separator": REDIS_KEY_SEPARATOR,
             "storage_type": "json",
         },
         "fields": [

--- a/langgraph/checkpoint/redis/shallow.py
+++ b/langgraph/checkpoint/redis/shallow.py
@@ -31,7 +31,8 @@ SCHEMAS = [
     {
         "index": {
             "name": "checkpoints",
-            "prefix": CHECKPOINT_PREFIX + REDIS_KEY_SEPARATOR,
+            "prefix": CHECKPOINT_PREFIX,
+            "key_separator": REDIS_KEY_SEPARATOR,
             "storage_type": "json",
         },
         "fields": [
@@ -44,7 +45,8 @@ SCHEMAS = [
     {
         "index": {
             "name": "checkpoints_blobs",
-            "prefix": CHECKPOINT_BLOB_PREFIX + REDIS_KEY_SEPARATOR,
+            "prefix": CHECKPOINT_BLOB_PREFIX,
+            "key_separator": REDIS_KEY_SEPARATOR,
             "storage_type": "json",
         },
         "fields": [
@@ -57,7 +59,8 @@ SCHEMAS = [
     {
         "index": {
             "name": "checkpoint_writes",
-            "prefix": CHECKPOINT_WRITE_PREFIX + REDIS_KEY_SEPARATOR,
+            "prefix": CHECKPOINT_WRITE_PREFIX,
+            "key_separator": REDIS_KEY_SEPARATOR,
             "storage_type": "json",
         },
         "fields": [

--- a/langgraph/store/redis/base.py
+++ b/langgraph/store/redis/base.py
@@ -44,7 +44,8 @@ SCHEMAS = [
     {
         "index": {
             "name": "store",
-            "prefix": STORE_PREFIX + REDIS_KEY_SEPARATOR,
+            "prefix": STORE_PREFIX,
+            "key_separator": REDIS_KEY_SEPARATOR,
             "storage_type": "json",
         },
         "fields": [
@@ -57,7 +58,8 @@ SCHEMAS = [
     {
         "index": {
             "name": "store_vectors",
-            "prefix": STORE_VECTOR_PREFIX + REDIS_KEY_SEPARATOR,
+            "prefix": STORE_VECTOR_PREFIX,
+            "key_separator": REDIS_KEY_SEPARATOR,
             "storage_type": "json",
         },
         "fields": [


### PR DESCRIPTION
Small update for better key creation safety through RedisVL. Looks like the `parent_checkpoint_id` issue still remains. Very strange that this small tweak wreaks havoc here.