### PR TITLE
 fix: handle both bytes and string Redis keys when decode_responses=True

### DIFF
--- a/langgraph/checkpoint/redis/__init__.py
+++ b/langgraph/checkpoint/redis/__init__.py
@@ -27,6 +27,7 @@ from langgraph.checkpoint.redis.util import (
     EMPTY_ID_SENTINEL,
     from_storage_safe_id,
     from_storage_safe_str,
+    safely_decode,
     to_storage_safe_id,
     to_storage_safe_str,
 )
@@ -518,4 +519,5 @@ __all__ = [
     "BaseRedisSaver",
     "ShallowRedisSaver",
     "AsyncShallowRedisSaver",
+    "safely_decode",
 ]

--- a/langgraph/checkpoint/redis/aio.py
+++ b/langgraph/checkpoint/redis/aio.py
@@ -33,6 +33,7 @@ from langgraph.checkpoint.redis.util import (
     EMPTY_ID_SENTINEL,
     from_storage_safe_id,
     from_storage_safe_str,
+    safely_decode,
     to_storage_safe_id,
     to_storage_safe_str,
 )
@@ -823,11 +824,20 @@ class AsyncRedisSaver(BaseRedisSaver[AsyncRedis, AsyncSearchIndex]):
             "*",
             None,
         )
+        # The result from self._redis.keys() can vary based on client implementation
         matching_keys = await self._redis.keys(pattern=writes_key)
+
         parsed_keys = [
-            BaseRedisSaver._parse_redis_checkpoint_writes_key(key.decode())
+            BaseRedisSaver._parse_redis_checkpoint_writes_key(safely_decode(key))
             for key in matching_keys
         ]
+        # Create key-parsed_key pairs and sort them
+        pairs = [
+            (key, parsed_key) for key, parsed_key in zip(matching_keys, parsed_keys)
+        ]
+        sorted_pairs = sorted(pairs, key=lambda x: x[1]["idx"])
+
+        # Build the dictionary with the sorted pairs
         pending_writes = BaseRedisSaver._load_writes(
             self.serde,
             {
@@ -835,9 +845,7 @@ class AsyncRedisSaver(BaseRedisSaver[AsyncRedis, AsyncSearchIndex]):
                     parsed_key["task_id"],
                     parsed_key["idx"],
                 ): await self._redis.json().get(key)
-                for key, parsed_key in sorted(
-                    zip(matching_keys, parsed_keys), key=lambda x: x[1]["idx"]
-                )
+                for key, parsed_key in sorted_pairs
             },
         )
         return pending_writes

--- a/langgraph/checkpoint/redis/ashallow.py
+++ b/langgraph/checkpoint/redis/ashallow.py
@@ -34,6 +34,7 @@ from langgraph.checkpoint.redis.base import (
     REDIS_KEY_SEPARATOR,
     BaseRedisSaver,
 )
+from langgraph.checkpoint.redis.util import safely_decode
 
 SCHEMAS = [
     {
@@ -246,7 +247,7 @@ class AsyncShallowRedisSaver(BaseRedisSaver[AsyncRedis, AsyncSearchIndex]):
             # Process each existing blob key to determine if it should be kept or deleted
             if existing_blob_keys:
                 for blob_key in existing_blob_keys:
-                    key_parts = blob_key.decode().split(REDIS_KEY_SEPARATOR)
+                    key_parts = safely_decode(blob_key).split(REDIS_KEY_SEPARATOR)
                     # The key format is checkpoint_blob:thread_id:checkpoint_ns:channel:version
                     if len(key_parts) >= 5:
                         channel = key_parts[3]
@@ -503,7 +504,7 @@ class AsyncShallowRedisSaver(BaseRedisSaver[AsyncRedis, AsyncSearchIndex]):
             # Process each existing writes key to determine if it should be kept or deleted
             if existing_writes_keys:
                 for write_key in existing_writes_keys:
-                    key_parts = write_key.decode().split(REDIS_KEY_SEPARATOR)
+                    key_parts = safely_decode(write_key).split(REDIS_KEY_SEPARATOR)
                     # The key format is checkpoint_write:thread_id:checkpoint_ns:checkpoint_id:task_id:idx
                     if len(key_parts) >= 5:
                         key_checkpoint_id = key_parts[3]
@@ -648,11 +649,20 @@ class AsyncShallowRedisSaver(BaseRedisSaver[AsyncRedis, AsyncSearchIndex]):
         writes_key = BaseRedisSaver._make_redis_checkpoint_writes_key(
             thread_id, checkpoint_ns, checkpoint_id, "*", None
         )
+        # The result from self._redis.keys() can vary based on client implementation
         matching_keys = await self._redis.keys(pattern=writes_key)
+
         parsed_keys = [
-            BaseRedisSaver._parse_redis_checkpoint_writes_key(key.decode())
+            BaseRedisSaver._parse_redis_checkpoint_writes_key(safely_decode(key))
             for key in matching_keys
         ]
+        # Create key-parsed_key pairs and sort them
+        pairs = [
+            (key, parsed_key) for key, parsed_key in zip(matching_keys, parsed_keys)
+        ]
+        sorted_pairs = sorted(pairs, key=lambda x: x[1]["idx"])
+
+        # Build the dictionary with the sorted pairs
         pending_writes = BaseRedisSaver._load_writes(
             self.serde,
             {
@@ -660,9 +670,7 @@ class AsyncShallowRedisSaver(BaseRedisSaver[AsyncRedis, AsyncSearchIndex]):
                     parsed_key["task_id"],
                     parsed_key["idx"],
                 ): await self._redis.json().get(key)
-                for key, parsed_key in sorted(
-                    zip(matching_keys, parsed_keys), key=lambda x: x[1]["idx"]
-                )
+                for key, parsed_key in sorted_pairs
             },
         )
         return pending_writes

--- a/langgraph/checkpoint/redis/base.py
+++ b/langgraph/checkpoint/redis/base.py
@@ -18,6 +18,7 @@ from langgraph.checkpoint.serde.base import SerializerProtocol
 from langgraph.checkpoint.serde.types import ChannelProtocol
 
 from langgraph.checkpoint.redis.util import (
+    safely_decode,
     to_storage_safe_id,
     to_storage_safe_str,
 )
@@ -479,20 +480,24 @@ class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexTyp
             None,
         )
 
-        # Cast the result to List[bytes] to help type checker
-        matching_keys: List[bytes] = self._redis.keys(pattern=writes_key)  # type: ignore[assignment]
+        # The result from self._redis.keys() can vary based on client implementation
+        matching_keys = self._redis.keys(pattern=writes_key)
 
         parsed_keys = [
-            BaseRedisSaver._parse_redis_checkpoint_writes_key(key.decode())
+            BaseRedisSaver._parse_redis_checkpoint_writes_key(safely_decode(key))
             for key in matching_keys
         ]
+        # Create key-parsed_key pairs and sort them
+        # Using type ignore because Redis client implementations can vary
+        pairs = [(key, parsed_key) for key, parsed_key in zip(matching_keys, parsed_keys)]  # type: ignore
+        sorted_pairs = sorted(pairs, key=lambda x: x[1]["idx"])
+
+        # Build the dictionary with the sorted pairs
         pending_writes = BaseRedisSaver._load_writes(
             self.serde,
             {
                 (parsed_key["task_id"], parsed_key["idx"]): self._redis.json().get(key)
-                for key, parsed_key in sorted(
-                    zip(matching_keys, parsed_keys), key=lambda x: x[1]["idx"]
-                )
+                for key, parsed_key in sorted_pairs
             },
         )
         return pending_writes

--- a/langgraph/checkpoint/redis/shallow.py
+++ b/langgraph/checkpoint/redis/shallow.py
@@ -26,6 +26,7 @@ from langgraph.checkpoint.redis.base import (
     REDIS_KEY_SEPARATOR,
     BaseRedisSaver,
 )
+from langgraph.checkpoint.redis.util import safely_decode
 
 SCHEMAS = [
     {
@@ -175,7 +176,7 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
         # Process each existing blob key to determine if it should be kept or deleted
         if existing_blob_keys:
             for blob_key in existing_blob_keys:
-                key_parts = blob_key.decode().split(REDIS_KEY_SEPARATOR)
+                key_parts = safely_decode(blob_key).split(REDIS_KEY_SEPARATOR)
                 # The key format is checkpoint_blob:thread_id:checkpoint_ns:channel:version
                 if len(key_parts) >= 5:
                     channel = key_parts[3]
@@ -490,7 +491,7 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
         # Process each existing writes key to determine if it should be kept or deleted
         if existing_writes_keys:
             for write_key in existing_writes_keys:
-                key_parts = write_key.decode().split(REDIS_KEY_SEPARATOR)
+                key_parts = safely_decode(write_key).split(REDIS_KEY_SEPARATOR)
                 # The key format is checkpoint_write:thread_id:checkpoint_ns:checkpoint_id:task_id:idx
                 if len(key_parts) >= 5:
                     key_checkpoint_id = key_parts[3]

--- a/langgraph/checkpoint/redis/util.py
+++ b/langgraph/checkpoint/redis/util.py
@@ -7,6 +7,8 @@ sentinel values are from the first run of the graph, so this should
 generally be correct.
 """
 
+from typing import Union
+
 EMPTY_STRING_SENTINEL = "__empty__"
 EMPTY_ID_SENTINEL = "00000000-0000-0000-0000-000000000000"
 
@@ -81,3 +83,22 @@ def from_storage_safe_id(value: str) -> str:
         return ""
     else:
         return value
+
+
+def safely_decode(key: Union[bytes, str]) -> str:
+    """
+    Safely decode a Redis key regardless of whether it's bytes or string.
+
+    This function handles both cases:
+    - When Redis client is configured with decode_responses=False (returns bytes)
+    - When Redis client is configured with decode_responses=True (returns strings)
+
+    Args:
+        key: The Redis key, either bytes or string
+
+    Returns:
+        The decoded key as a string
+    """
+    if isinstance(key, bytes):
+        return key.decode()
+    return key

--- a/tests/test_decode_responses.py
+++ b/tests/test_decode_responses.py
@@ -1,0 +1,101 @@
+"""Test Redis key decoding functionality to ensure it works with both decode_responses=True and False."""
+
+import pytest
+from redis import Redis
+from redisvl.redis.connection import RedisConnectionFactory
+
+from langgraph.checkpoint.redis.base import BaseRedisSaver
+from langgraph.checkpoint.redis.util import safely_decode
+
+
+def test_safely_decode():
+    """Test the safely_decode function with both bytes and strings."""
+    # Test with bytes
+    assert safely_decode(b"test_key") == "test_key"
+
+    # Test with string
+    assert safely_decode("test_key") == "test_key"
+
+
+@pytest.fixture
+def redis_client_decoded():
+    """Redis client with decode_responses=True."""
+    client = Redis.from_url("redis://localhost:6379", decode_responses=True)
+    yield client
+    client.close()
+
+
+@pytest.fixture
+def redis_client_bytes():
+    """Redis client with decode_responses=False (default)."""
+    client = Redis.from_url("redis://localhost:6379", decode_responses=False)
+    yield client
+    client.close()
+
+
+def test_redis_keys_with_decode_responses(redis_client_decoded, redis_client_bytes):
+    """Test that redis.keys() behaves as expected with different decode_responses settings."""
+    # Generate a unique key prefix for this test
+    test_key_prefix = "test_decode_responses_"
+
+    # Create some test keys
+    for i in range(3):
+        key = f"{test_key_prefix}{i}"
+        redis_client_bytes.set(key, f"value{i}")
+
+    try:
+        # Test with decode_responses=False (returns bytes)
+        keys_bytes = redis_client_bytes.keys(f"{test_key_prefix}*")
+        assert all(isinstance(k, bytes) for k in keys_bytes)
+
+        # Test with decode_responses=True (returns strings)
+        keys_str = redis_client_decoded.keys(f"{test_key_prefix}*")
+        assert all(isinstance(k, str) for k in keys_str)
+
+        # Test that our safely_decode function works with both
+        decoded_bytes = [safely_decode(k) for k in keys_bytes]
+        decoded_str = [safely_decode(k) for k in keys_str]
+
+        # Both should now be lists of strings
+        assert all(isinstance(k, str) for k in decoded_bytes)
+        assert all(isinstance(k, str) for k in decoded_str)
+
+        # Both should contain the same keys
+        assert sorted(decoded_bytes) == sorted(decoded_str)
+
+    finally:
+        # Clean up
+        for i in range(3):
+            redis_client_bytes.delete(f"{test_key_prefix}{i}")
+
+
+def test_parse_redis_key_with_different_clients(
+    redis_client_decoded, redis_client_bytes
+):
+    """Test that our _parse_redis_checkpoint_writes_key method works correctly."""
+    # Create a test key using the format expected by the parser
+    from langgraph.checkpoint.redis.base import (
+        CHECKPOINT_WRITE_PREFIX,
+        REDIS_KEY_SEPARATOR,
+    )
+
+    test_key = f"{CHECKPOINT_WRITE_PREFIX}{REDIS_KEY_SEPARATOR}thread1{REDIS_KEY_SEPARATOR}ns1{REDIS_KEY_SEPARATOR}cp1{REDIS_KEY_SEPARATOR}task1{REDIS_KEY_SEPARATOR}0"
+
+    # Test parsing with bytes key (as would come from decode_responses=False)
+    bytes_key = test_key.encode()
+    parsed_bytes = BaseRedisSaver._parse_redis_checkpoint_writes_key(
+        safely_decode(bytes_key)
+    )
+
+    # Test parsing with string key (as would come from decode_responses=True)
+    parsed_str = BaseRedisSaver._parse_redis_checkpoint_writes_key(
+        safely_decode(test_key)
+    )
+
+    # Both should produce the same result
+    assert parsed_bytes == parsed_str
+    assert parsed_bytes["thread_id"] == "thread1"
+    assert parsed_bytes["checkpoint_ns"] == "ns1"
+    assert parsed_bytes["checkpoint_id"] == "cp1"
+    assert parsed_bytes["task_id"] == "task1"
+    assert parsed_bytes["idx"] == "0"


### PR DESCRIPTION
  Resolves issue #24 where Redis key decoding would fail when a client
  was configured with decode_responses=True. Adds a new `safely_decode`
  utility function that handles both bytes and string keys.