### PR TITLE
fix: cleanup blobs and writes for shallow classes

### DIFF
--- a/langgraph/checkpoint/redis/shallow.py
+++ b/langgraph/checkpoint/redis/shallow.py
@@ -26,6 +26,10 @@ from langgraph.checkpoint.redis.base import (
     REDIS_KEY_SEPARATOR,
     BaseRedisSaver,
 )
+from langgraph.checkpoint.redis.util import (
+    to_storage_safe_id,
+    to_storage_safe_str,
+)
 
 SCHEMAS = [
     {
@@ -688,15 +692,12 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
     @staticmethod
     def _make_shallow_redis_checkpoint_key(thread_id: str, checkpoint_ns: str) -> str:
         """Create a key for shallow checkpoints using only thread_id and checkpoint_ns."""
-        return REDIS_KEY_SEPARATOR.join([CHECKPOINT_PREFIX, thread_id, checkpoint_ns])
-
-    @staticmethod
-    def _make_shallow_redis_checkpoint_blob_key(
-        thread_id: str, checkpoint_ns: str, channel: str
-    ) -> str:
-        """Create a key for a blob in a shallow checkpoint."""
         return REDIS_KEY_SEPARATOR.join(
-            [CHECKPOINT_BLOB_PREFIX, thread_id, checkpoint_ns, channel]
+            [
+                CHECKPOINT_PREFIX,
+                str(to_storage_safe_id(thread_id)),
+                to_storage_safe_str(checkpoint_ns),
+            ]
         )
 
     @staticmethod
@@ -704,9 +705,13 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
         thread_id: str, checkpoint_ns: str
     ) -> str:
         """Create a pattern to match all blob keys for a thread and namespace."""
-        return (
-            REDIS_KEY_SEPARATOR.join([CHECKPOINT_BLOB_PREFIX, thread_id, checkpoint_ns])
-            + ":*"
+        return REDIS_KEY_SEPARATOR.join(
+            [
+                CHECKPOINT_BLOB_PREFIX,
+                str(to_storage_safe_id(thread_id)),
+                to_storage_safe_str(checkpoint_ns),
+                "*",
+            ]
         )
 
     @staticmethod
@@ -714,9 +719,11 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
         thread_id: str, checkpoint_ns: str
     ) -> str:
         """Create a pattern to match all writes keys for a thread and namespace."""
-        return (
-            REDIS_KEY_SEPARATOR.join(
-                [CHECKPOINT_WRITE_PREFIX, thread_id, checkpoint_ns]
-            )
-            + ":*"
+        return REDIS_KEY_SEPARATOR.join(
+            [
+                CHECKPOINT_WRITE_PREFIX,
+                str(to_storage_safe_id(thread_id)),
+                to_storage_safe_str(checkpoint_ns),
+                "*",
+            ]
         )

--- a/tests/test_shallow_async.py
+++ b/tests/test_shallow_async.py
@@ -12,6 +12,7 @@ from redis.asyncio import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from langgraph.checkpoint.redis.ashallow import AsyncShallowRedisSaver
+from langgraph.checkpoint.redis.base import CHECKPOINT_BLOB_PREFIX
 
 
 @pytest.fixture
@@ -96,7 +97,10 @@ async def test_only_latest_checkpoint(
         }
     )
     checkpoint_1 = test_data["checkpoints"][0]
-    await saver.aput(config_1, checkpoint_1, test_data["metadata"][0], {})
+    channel_versions_1 = {"test_channel": "1"}
+    await saver.aput(
+        config_1, checkpoint_1, test_data["metadata"][0], channel_versions_1
+    )
 
     # Create second checkpoint
     config_2 = RunnableConfig(
@@ -108,12 +112,18 @@ async def test_only_latest_checkpoint(
         }
     )
     checkpoint_2 = test_data["checkpoints"][1]
-    await saver.aput(config_2, checkpoint_2, test_data["metadata"][1], {})
+    channel_versions_2 = {"test_channel": "2"}
+    await saver.aput(
+        config_2, checkpoint_2, test_data["metadata"][1], channel_versions_2
+    )
 
-    # Verify only latest checkpoint exists
+    # Verify only latest checkpoint and blobs exists
     results = [c async for c in saver.alist(None)]
     assert len(results) == 1
     assert results[0].config["configurable"]["checkpoint_id"] == checkpoint_2["id"]
+
+    blobs = list(await saver._redis.keys(CHECKPOINT_BLOB_PREFIX + ":*"))
+    assert len(blobs) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to issue #13

This PR addresses an incomplete cleanup in `ShallowRedisSaver` and `AsyncShallowRedisSaver` related to leftover blobs and writes.

The initial fix ([commit](https://github.com/redis-developer/langgraph-redis/commit/d21ee55f567779a8908b891832ef290ed0ea3397)) did not fully remove all related keys. Specifically, the helper methods `_make_shallow_redis_checkpoint_blob_key_pattern` and `_make_shallow_redis_checkpoint_writes_key_pattern` did not apply the `to_storage_safe_id` and `to_storage_safe_str` utilities, which are used by the base class during [blob dumping](https://github.com/redis-developer/langgraph-redis/blob/main/langgraph/checkpoint/redis/shallow.py#L203).

As a result, when `checkpoint_ns` was empty and `channel_versions` was populated, the cleanup logic failed to match and remove the correct keys — leading to orphaned blobs and write entries.

This PR ensures consistency in key generation across dumping and cleanup, allowing complete and reliable deletion of checkpoint-related data.