### PR TITLE
Fix docker issues, TTL cleanup

### DIFF
--- a/langgraph/checkpoint/redis/__init__.py
+++ b/langgraph/checkpoint/redis/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
-from contextlib import contextmanager
 import logging
+from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
 
 from langchain_core.runnables import RunnableConfig

--- a/langgraph/checkpoint/redis/types.py
+++ b/langgraph/checkpoint/redis/types.py
@@ -2,8 +2,8 @@ from typing import Any, Optional, TypeVar, Union
 
 from redis import Redis
 from redis.asyncio import Redis as AsyncRedis
-from redis.cluster import RedisCluster
 from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
+from redis.cluster import RedisCluster
 from redisvl.index import AsyncSearchIndex, SearchIndex
 
 RedisClientType = TypeVar(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
-import time
 import socket
+import time
 
 import pytest
 from redis.asyncio import Redis

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,12 +3,13 @@ services:
   redis:
     image: "${REDIS_IMAGE}"
     ports:
-      - "6379"
+      - target: 6379
+        published: 0
+        protocol: tcp
+        mode: host
     environment:
       - "REDIS_ARGS=--save '' --appendonly no"
     deploy:
       replicas: 1
       restart_policy:
         condition: on-failure
-    labels:
-      - "com.docker.compose.publishers=redis,6379,6379"

--- a/tests/test_async_cluster_mode.py
+++ b/tests/test_async_cluster_mode.py
@@ -10,8 +10,8 @@ from redis.asyncio.cluster import (
     RedisCluster as AsyncRedisCluster,  # Import actual for isinstance checks if needed by store
 )
 
-from langgraph.store.redis import AsyncRedisStore
 from langgraph.checkpoint.redis.aio import AsyncRedisSaver
+from langgraph.store.redis import AsyncRedisStore
 
 
 # Override session-scoped redis_container fixture to prevent Docker operations and provide dummy host/port

--- a/tests/test_cluster_mode.py
+++ b/tests/test_cluster_mode.py
@@ -7,19 +7,19 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata
 from langgraph.store.base import GetOp, ListNamespacesOp, PutOp, SearchOp
 from redis import Redis
 from redis.cluster import RedisCluster as SyncRedisCluster
 from ulid import ULID
 
+from langgraph.checkpoint.redis import RedisSaver
 from langgraph.store.redis import RedisStore
 from langgraph.store.redis.base import (
     REDIS_KEY_SEPARATOR,
     STORE_PREFIX,
     STORE_VECTOR_PREFIX,
 )
-from langgraph.checkpoint.redis import RedisSaver
-from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata
 
 
 # Override session-scoped redis_container fixture to prevent Docker operations and provide dummy host/port


### PR DESCRIPTION
This PR fixes an issue with local testing and Docker where redis containers would fail to come up. Previously, each pytest xdist worker would attempt to connect to its own redis instance. If the instance failed to come up in time, the configuration defaulted to localhost: 6379. As long as a redis instance is running locally, the problem would have been masked, but this causes the tests to fail when a local redis instance is unavailable.

We attempt to resolve the issue by waiting longer for individual redis containers to become available. In the previous configuration, it was also possible for multiple xdist workers to start redis instances mapped to the same port (causing conflicts). We resolve this by giving each xdist worker a random, non-conflicting host port for their redis instance.