### PR TITLE
Add per thread locking for checkpointer

### DIFF
--- a/tests/test_thread_lock.py
+++ b/tests/test_thread_lock.py
@@ -1,40 +1,50 @@
-import concurrent.futures
+import concurrent.futures 
+import pytest  
+from langchain_core.runnables import RunnableConfig  
+from langgraph.checkpoint.base import empty_checkpoint 
+from langgraph.checkpoint.redis import RedisSaver  
 
-import pytest
-from langchain_core.runnables import RunnableConfig
-from langgraph.checkpoint.base import empty_checkpoint
-
-from langgraph.checkpoint.redis import RedisSaver
-
-
+# Helper function to increment a value in a thread-safe manner
 def _increment(
     checkpointer: RedisSaver, config: RunnableConfig, iterations: int
 ) -> None:
-    for _ in range(iterations):
+    for _ in range(iterations):  # Loop for the specified number of iterations
+        # Acquire a thread lock for the given thread ID
         with checkpointer.thread_lock(config["configurable"]["thread_id"]):
+            # Retrieve the current checkpoint tuple
             tup = checkpointer.get_tuple(config)
+            # Use an empty checkpoint if none exists
             cp = tup.checkpoint if tup else empty_checkpoint()
+            # Initialize or update the "count" in channel_values and channel_versions
             cp.setdefault("channel_values", {}).setdefault("count", 0)
             cp.setdefault("channel_versions", {}).setdefault("count", "0")
-            cp["channel_values"]["count"] += 1
-            cp["channel_versions"]["count"] = str(cp["channel_values"]["count"])
+            cp["channel_values"]["count"] += 1  # Increment the count
+            cp["channel_versions"]["count"] = str(cp["channel_values"]["count"])  # Update version
+            # Save the updated checkpoint
             checkpointer.put(config, cp, {}, {"count": cp["channel_versions"]["count"]})
 
-
-@pytest.mark.skip("Requires running Redis container")
+# Test function to verify thread-safe serialization of checkpoints
 def test_thread_lock_serialization(redis_url: str) -> None:
+    # Create a RedisSaver instance using the provided Redis URL
     with RedisSaver.from_conn_string(redis_url) as saver:
-        saver.setup()
+        saver.setup()  # Perform any necessary setup
+        # Define a configuration for the checkpoint
         config: RunnableConfig = {
             "configurable": {"thread_id": "t", "checkpoint_ns": ""}
         }
+        # Initialize the checkpoint with an empty state
         saver.put(config, empty_checkpoint(), {}, {})
 
+        # Use a ThreadPoolExecutor to simulate concurrent access
         with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            # Submit two tasks to increment the checkpoint concurrently
             futures = [executor.submit(_increment, saver, config, 5) for _ in range(2)]
+            # Wait for all tasks to complete
             for f in futures:
                 f.result()
 
+        # Retrieve the final checkpoint
         final = saver.get_tuple(config)
-        assert final is not None
+        assert final is not None  # Ensure the checkpoint exists
+        # Verify that the count has been incremented correctly
         assert final.checkpoint["channel_values"]["count"] == 10

--- a/tests/test_thread_lock.py
+++ b/tests/test_thread_lock.py
@@ -1,0 +1,40 @@
+import concurrent.futures
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import empty_checkpoint
+
+from langgraph.checkpoint.redis import RedisSaver
+
+
+def _increment(
+    checkpointer: RedisSaver, config: RunnableConfig, iterations: int
+) -> None:
+    for _ in range(iterations):
+        with checkpointer.thread_lock(config["configurable"]["thread_id"]):
+            tup = checkpointer.get_tuple(config)
+            cp = tup.checkpoint if tup else empty_checkpoint()
+            cp.setdefault("channel_values", {}).setdefault("count", 0)
+            cp.setdefault("channel_versions", {}).setdefault("count", "0")
+            cp["channel_values"]["count"] += 1
+            cp["channel_versions"]["count"] = str(cp["channel_values"]["count"])
+            checkpointer.put(config, cp, {}, {"count": cp["channel_versions"]["count"]})
+
+
+@pytest.mark.skip("Requires running Redis container")
+def test_thread_lock_serialization(redis_url: str) -> None:
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        config: RunnableConfig = {
+            "configurable": {"thread_id": "t", "checkpoint_ns": ""}
+        }
+        saver.put(config, empty_checkpoint(), {}, {})
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(_increment, saver, config, 5) for _ in range(2)]
+            for f in futures:
+                f.result()
+
+        final = saver.get_tuple(config)
+        assert final is not None
+        assert final.checkpoint["channel_values"]["count"] == 10

--- a/tests/test_thread_lock.py
+++ b/tests/test_thread_lock.py
@@ -1,8 +1,11 @@
-import concurrent.futures 
-import pytest  
-from langchain_core.runnables import RunnableConfig  
-from langgraph.checkpoint.base import empty_checkpoint 
-from langgraph.checkpoint.redis import RedisSaver  
+import concurrent.futures
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import empty_checkpoint
+
+from langgraph.checkpoint.redis import RedisSaver
+
 
 # Helper function to increment a value in a thread-safe manner
 def _increment(
@@ -19,9 +22,12 @@ def _increment(
             cp.setdefault("channel_values", {}).setdefault("count", 0)
             cp.setdefault("channel_versions", {}).setdefault("count", "0")
             cp["channel_values"]["count"] += 1  # Increment the count
-            cp["channel_versions"]["count"] = str(cp["channel_values"]["count"])  # Update version
+            cp["channel_versions"]["count"] = str(
+                cp["channel_values"]["count"]
+            )  # Update version
             # Save the updated checkpoint
             checkpointer.put(config, cp, {}, {"count": cp["channel_versions"]["count"]})
+
 
 # Test function to verify thread-safe serialization of checkpoints
 def test_thread_lock_serialization(redis_url: str) -> None:


### PR DESCRIPTION

Add per-thread locking to RedisSaver for safe concurrent checkpoint writes

**## Motivation**
LangGraph is often deployed with multiple agent instances to horizontally scale and serve users concurrently in production. Without any locking, if two agents handle messages for the *same* `thread_id` at the same time, they both:

1. Load the identical “latest” checkpoint state
2. Apply their own updates in isolation
3. Write back, with the second write clobbering the first

This race condition leads to lost updates and inconsistent state. Introducing an *optional*, per-thread distributed lock guarantees that each `get`/`put` cycle for a given `thread_id` happens atomically, preserving every agent’s changes under concurrent load.

**## What Changed**

* **New constructor params:** `lock_block` (bool) and `lock_timeout` (float) on both `RedisSaver.from_conn_string(…)` and `AsyncRedisSaver` (defaults: no blocking, infinite timeout).
* **Added** `thread_lock(thread_id, block=None, timeout=None)` context manager (and `athread_lock` for async) to serialize critical sections per thread.
* **Enhanced** `put()` to merge `pending_sends` into `checkpoint["channel_values"]` and persist them into the Redis hash.
* **Updated** `get()` to rehydrate all stored channel values from Redis into the checkpoint dict.
* **Async support:** Proper `await`‑based lock acquisition/release in `AsyncRedisSaver` to satisfy MyPy.
* **Tests:** Added regression test (`test_thread_lock_serialization`) that spins up two threads incrementing a counter under `thread_lock` and verifies the final count is 10.
* **Docs:** Updated constructor docstrings and README snippet with usage examples.

**## Usage**

```python
# Block for up to 1 second when acquiring the lock
with RedisSaver.from_conn_string(
    "redis://localhost:6379", lock_block=True, lock_timeout=1.0
) as saver:
    saver.setup()

# Serialize per-thread checkpoint updates
with saver.thread_lock("my-thread"):
    tup = saver.get_tuple(config)
    # modify tup.checkpoint, e.g.:
    tup.checkpoint["channel_values"]["count"] += 1
    saver.put(config, tup.checkpoint, {}, tup.new_versions)
```

**## Backwards Compatibility**
Locking is entirely opt‑in. Existing code paths (no `lock_block` and no explicit `thread_lock`) behave exactly as before.
