### PR TITLE
Update Redis Constraint to Reflect Documentation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1096,7 +1096,7 @@ description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version < \"3.11\""
+markers = "python_version < \"3.13\""
 files = [
     {file = "numpy-2.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:51129a29dbe56f9ca83438b706e2e69a39892b5eda6cedcb6b0c9fdc9b0d3ece"},
     {file = "numpy-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f15975dfec0cf2239224d80e32c3170b1d168335eaedee69da84fbe9f1f9cd04"},
@@ -1152,7 +1152,7 @@ description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "python_version >= \"3.11\""
+markers = "python_version == \"3.13\""
 files = [
     {file = "numpy-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0ffc4f5caba7dfcbe944ed674b7eef683c7e94874046454bb79ed7ee0236f59d"},
     {file = "numpy-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7e946c7170858a0295f79a60214424caac2ffdb0063d4d79cb681f9aa0aa569"},
@@ -2673,4 +2673,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.14"
-content-hash = "004dcc029a0670478fe5b888b995407c22b31fee83c38bc2c6f89197e0f550b0"
+content-hash = "d0419622e53316243bb16adb07eab6c1ec0d929d03bb0756816a41fb8b312112"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ packages = [{ include = "langgraph" }]
 python = ">=3.9,<3.14"
 langgraph-checkpoint = ">=2.0.21,<3.0.0"
 redisvl = ">=0.5.1,<1.0.0"
-redis = ">=5.2.1,<7.0"
+redis = ">=5.2.1,<7.0.0"
 orjson = "^3.9.0"
 tomli = { version = "^2.0.1", python = "<3.11" }
 


### PR DESCRIPTION
In PR #67, the Redis constraint was removed (`>=5.0,<7.0`) and reintroduced for >6.2.0 in https://github.com/redis-developer/langgraph-redis/commit/13ddc962b884b2811cbb598118512c864701878b. As per the README, `redis>=5.2.1` is the minimum version supported.

I don't, as far as I can tell, believe the `^6.2.0` constraint is correct. However, if it is, I can alternatively update the documentation.