### PR TITLE
change serde order for better compatibility

### DIFF
--- a/langgraph/checkpoint/redis/base.py
+++ b/langgraph/checkpoint/redis/base.py
@@ -417,10 +417,11 @@ class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexTyp
             if obj.get("lc") in (1, 2) and obj.get("type") == "constructor":
                 try:
                     # Use the serde's reviver to reconstruct the object
-                    if hasattr(self.serde, "_reviver"):
-                        return self.serde._reviver(obj)
-                    elif hasattr(self.serde, "_revive_if_needed"):
+
+                    if hasattr(self.serde, "_revive_if_needed"):
                         return self.serde._revive_if_needed(obj)
+                    elif hasattr(self.serde, "_reviver"):
+                        return self.serde._reviver(obj)
                     else:
                         # Log warning if serde doesn't have reviver
                         logger.warning(


### PR DESCRIPTION
JsonPlusRedisSerializer make obj to LC constructor format, but current implementation only call serde._reviver() , it caused user-defined be kept in constructor dicts inside checkpoint state. 
If user use basemodel as state, it cant be deserializes successful.

This is inconsistent behavior vs sqlite backends. With it, pydantic is usable.

So suggest update to prefer _revive_if_needed over _reviver for Redis checkpoint deserialization