### PR TITLE
fix(security): update langchain-core to 1.2.6 (CVE-2025-68664)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1046,14 +1046,14 @@ pydantic = ">=2.7.4,<3.0.0"
 
 [[package]]
 name = "langchain-core"
-version = "1.1.3"
+version = "1.2.6"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main", "dev"]
 files = [
-    {file = "langchain_core-1.1.3-py3-none-any.whl", hash = "sha256:e06efbf55bf7c7e4fcffc2f5b0a39a855176df16b02077add063534d7dabb740"},
-    {file = "langchain_core-1.1.3.tar.gz", hash = "sha256:ff0bc5e6e701c4d6fe00c73c4feae5c993a7a8e0b91f0a1d07015277d4634275"},
+    {file = "langchain_core-1.2.6-py3-none-any.whl", hash = "sha256:aa6ed954b4b1f4504937fe75fdf674317027e9a91ba7a97558b0de3dc8004e34"},
+    {file = "langchain_core-1.2.6.tar.gz", hash = "sha256:b4e7841dd7f8690375aa07c54739178dc2c635147d475e0c2955bf82a1afa498"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Addresses critical serialization injection vulnerability (CVSS 9.3) that could allow secret extraction via dumps/loads APIs.

- Vulnerability: GHSA-c67j-w6g6-q2cm
- Affected: langchain-core >= 1.0.0, < 1.2.5
- Fixed in: langchain-core 1.2.5+