### PR TITLE
chore(deps): widen langgraph-checkpoint upper bound to <5.0.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4114,4 +4114,4 @@ cffi = ["cffi (>=1.17,<2.0)", "cffi (>=2.0.0b)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "50f5e4f06a7d7fd22b2cfabad4511399042442ad385014b3e0e980a9958ffa02"
+content-hash = "f4a1e00c3b4edaa0eb4aed2dcc6f7e558f5a4141ee38a5e8458475ab85aeaf72"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ packages = [{ include = "langgraph" }]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
-langgraph-checkpoint = ">=3.0.0,<4.0.0"
+langgraph-checkpoint = ">=3.0.0,<5.0.0"
 redisvl = ">=0.11.0,<1.0.0"
 redis = ">=5.2.1"
 orjson = "^3.9.0"


### PR DESCRIPTION
## Summary

- Widen `langgraph-checkpoint` dependency from `>=3.0.0,<4.0.0` to `>=3.0.0,<5.0.0`
- Allows downstream projects to resolve `langgraph-checkpoint>=4.0.0` which contains a security fix for CVE-2026-27794 (pickle deserialization in `BaseCache`)
- The only breaking change in 4.0.0 (`pickle_fallback=False` default in `JsonPlusSerializer`) has no impact on this library since `JsonPlusRedisSerializer` uses orjson/msgpack and never pickle

## Test plan

- [x] Verified no pickle usage anywhere in the codebase
- [x] Confirmed `JsonPlusRedisSerializer` fully overrides `dumps_typed`/`loads_typed` with orjson + msgpack fallback
- [x] Full test suite passes (`make test-all`)

Closes #152