### PR TITLE
fix(middleware): fix ConversationMemoryMiddleware not storing or retrieving messages

### DIFF
--- a/langgraph/middleware/redis/conversation_memory.py
+++ b/langgraph/middleware/redis/conversation_memory.py
@@ -13,6 +13,11 @@ from langchain.agents.middleware.types import (
     ModelRequest,
     ModelResponse,
 )
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+)
 from langchain_core.messages import ToolMessage as LangChainToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
@@ -124,25 +129,27 @@ class ConversationMemoryMiddleware(AsyncRedisMiddleware):
 
         return ""
 
-    def _format_context_messages(
-        self, context: List[Dict[str, Any]]
-    ) -> List[Dict[str, str]]:
+    def _format_context_messages(self, context: List[Dict[str, Any]]) -> List[Any]:
         """Format retrieved context messages for injection.
 
         Args:
             context: List of retrieved context messages.
 
         Returns:
-            Formatted messages ready for injection.
+            Formatted LangChain message objects ready for injection.
         """
-        formatted = []
+        formatted: List[Any] = []
         for msg in context:
-            formatted.append(
-                {
-                    "role": msg.get("role", "user"),
-                    "content": msg.get("content", ""),
-                }
-            )
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            if role == "system":
+                formatted.append(SystemMessage(content=content))
+            elif role in ("user", "human"):
+                formatted.append(HumanMessage(content=content))
+            elif role in ("llm", "ai", "assistant"):
+                formatted.append(AIMessage(content=content))
+            else:
+                formatted.append(HumanMessage(content=content))
         return formatted
 
     async def awrap_model_call(
@@ -193,10 +200,9 @@ class ConversationMemoryMiddleware(AsyncRedisMiddleware):
             formatted_context = self._format_context_messages(context_messages)
             # Insert context before the current messages
             # We add them as a context block
-            context_note = {
-                "role": "system",
-                "content": "Relevant context from previous conversations:",
-            }
+            context_note = SystemMessage(
+                content="Relevant context from previous conversations:"
+            )
             enhanced_messages = [context_note] + formatted_context + list(messages)
             # Support both dict-style and LangChain ModelRequest types
             if isinstance(request, dict):
@@ -211,8 +217,15 @@ class ConversationMemoryMiddleware(AsyncRedisMiddleware):
         try:
             # Get the user message
             user_content = query
-            # Get the assistant response (support both dict and LangChain types)
-            if isinstance(response, dict):
+            # Get the assistant response (support ModelResponse, dict, and
+            # other LangChain types)
+            if hasattr(response, "result") and isinstance(response.result, list):
+                # ModelResponse: result is list[BaseMessage]
+                if response.result:
+                    assistant_content = getattr(response.result[-1], "content", "")
+                else:
+                    assistant_content = ""
+            elif isinstance(response, dict):
                 assistant_content = response.get("content", "")
             else:
                 assistant_content = getattr(response, "content", "")
@@ -226,7 +239,7 @@ class ConversationMemoryMiddleware(AsyncRedisMiddleware):
             if assistant_content:
                 self._history.add_messages(
                     [
-                        {"role": "assistant", "content": assistant_content},
+                        {"role": "llm", "content": assistant_content},
                     ]
                 )
         except Exception as e:

--- a/tests/integration/test_middleware_end_to_end.py
+++ b/tests/integration/test_middleware_end_to_end.py
@@ -4,6 +4,8 @@ These tests simulate real agent workflow patterns.
 """
 
 import pytest
+from langchain.agents.middleware.types import ModelResponse
+from langchain_core.messages import AIMessage
 from testcontainers.redis import RedisContainer
 
 from langgraph.middleware.redis import (
@@ -132,28 +134,34 @@ class TestMultiTurnConversation:
 
         async with ConversationMemoryMiddleware(config) as middleware:
             # Simulate multi-turn conversation
-            async def mock_llm(request: dict) -> dict:
+            async def mock_llm(request: dict) -> ModelResponse:
                 messages = request.get("messages", [])
                 user_msg = ""
                 for m in reversed(messages):
                     if isinstance(m, dict) and m.get("role") == "user":
                         user_msg = m.get("content", "")
                         break
+                    elif hasattr(m, "type") and m.type == "human":
+                        user_msg = m.content
+                        break
 
-                return {"content": f"I received: {user_msg}"}
+                return ModelResponse(
+                    result=[AIMessage(content=f"I received: {user_msg}")]
+                )
 
             # Turn 1
             request1 = {"messages": [{"role": "user", "content": "Hello, I'm Alice."}]}
             response1 = await middleware.awrap_model_call(request1, mock_llm)
-            assert "Alice" in response1["content"]
+            assert "Alice" in response1.result[0].content
 
             # Turn 2
             request2 = {
                 "messages": [{"role": "user", "content": "What's my name again?"}]
             }
             response2 = await middleware.awrap_model_call(request2, mock_llm)
-            # The middleware should have injected context
-            assert "content" in response2
+            # The middleware should have injected context and returned a ModelResponse
+            assert hasattr(response2, "result")
+            assert len(response2.result) > 0
 
 
 @requires_sentence_transformers

--- a/tests/integration/test_middleware_notebook_scenarios.py
+++ b/tests/integration/test_middleware_notebook_scenarios.py
@@ -7,6 +7,7 @@ demonstrated in the example notebooks.
 from unittest.mock import MagicMock
 
 import pytest
+from langchain.agents.middleware.types import ModelResponse
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from testcontainers.redis import RedisContainer
 
@@ -409,10 +410,12 @@ class TestConversationMemoryNotebookScenario:
             await middleware_user1._ensure_initialized_async()
             await middleware_user2._ensure_initialized_async()
 
-            async def mock_llm(request: dict) -> dict:
+            async def mock_llm(request: dict) -> ModelResponse:
                 # Extract messages to check context
                 msgs = request.get("messages", [])
-                return {"content": f"Response with {len(msgs)} messages"}
+                return ModelResponse(
+                    result=[AIMessage(content=f"Response with {len(msgs)} messages")]
+                )
 
             # User 1 sends a message
             request1 = {
@@ -429,6 +432,57 @@ class TestConversationMemoryNotebookScenario:
         finally:
             await middleware_user1.aclose()
             await middleware_user2.aclose()
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_recall(self, redis_url: str) -> None:
+        """Test that middleware stores and retrieves messages across turns."""
+        import uuid
+
+        unique_name = f"memory_recall_test_{uuid.uuid4().hex[:8]}"
+        config = ConversationMemoryConfig(
+            redis_url=redis_url,
+            name=unique_name,
+            session_tag="recall_test_session",
+            top_k=5,
+            distance_threshold=0.9,
+        )
+
+        async with ConversationMemoryMiddleware(config) as middleware:
+            injected_context: list = []
+
+            async def mock_llm(request: dict) -> ModelResponse:
+                msgs = request.get("messages", [])
+                # Track injected context messages (beyond the user's own message)
+                injected_context.clear()
+                injected_context.extend(msgs)
+                return ModelResponse(result=[AIMessage(content="Got it, thanks!")])
+
+            # Turn 1: talk about Python programming
+            request1 = {
+                "messages": [
+                    HumanMessage(
+                        content="I really enjoy Python programming and data science"
+                    )
+                ]
+            }
+            await middleware.awrap_model_call(request1, mock_llm)
+
+            # Turn 2: ask about Python programming - semantically very similar
+            request2 = {
+                "messages": [
+                    HumanMessage(
+                        content="Tell me more about Python programming and data science"
+                    )
+                ]
+            }
+            await middleware.awrap_model_call(request2, mock_llm)
+
+            # The middleware should have injected context from Turn 1
+            # Total messages should be more than just the 1 user message
+            assert len(injected_context) > 1, (
+                "Expected context injection from Turn 1 but got only the "
+                f"user message. Messages: {injected_context}"
+            )
 
 
 @requires_sentence_transformers

--- a/tests/test_middleware_conversation_memory.py
+++ b/tests/test_middleware_conversation_memory.py
@@ -3,6 +3,8 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain.agents.middleware.types import ModelResponse
+from langchain_core.messages import AIMessage
 
 from langgraph.middleware.redis.types import ConversationMemoryConfig
 
@@ -88,11 +90,11 @@ class TestConversationMemoryMiddleware:
             middleware = ConversationMemoryMiddleware(config)
             await middleware._ensure_initialized_async()
 
-            async def mock_handler(request: dict) -> dict:
+            async def mock_handler(request: dict) -> ModelResponse:
                 # Check that context was added (messages captured for potential assertions)
                 _messages = request.get("messages", [])  # noqa: F841
                 # Should have injected context
-                return {"content": "Response"}
+                return ModelResponse(result=[AIMessage(content="Response")])
 
             request = {"messages": [{"role": "user", "content": "New question"}]}
             await middleware.awrap_model_call(request, mock_handler)
@@ -120,14 +122,22 @@ class TestConversationMemoryMiddleware:
             middleware = ConversationMemoryMiddleware(config)
             await middleware._ensure_initialized_async()
 
-            async def mock_handler(request: dict) -> dict:
-                return {"content": "Model response"}
+            async def mock_handler(request: dict) -> ModelResponse:
+                return ModelResponse(result=[AIMessage(content="Model response")])
 
             request = {"messages": [{"role": "user", "content": "User question"}]}
             await middleware.awrap_model_call(request, mock_handler)
 
             # Should have stored both user message and assistant response
-            assert mock_history.add_messages.called
+            assert mock_history.add_messages.call_count == 2
+            # First call: user message
+            user_call = mock_history.add_messages.call_args_list[0]
+            assert user_call[0][0][0]["role"] == "user"
+            assert user_call[0][0][0]["content"] == "User question"
+            # Second call: assistant message with "llm" role for redisvl
+            llm_call = mock_history.add_messages.call_args_list[1]
+            assert llm_call[0][0][0]["role"] == "llm"
+            assert llm_call[0][0][0]["content"] == "Model response"
 
     @pytest.mark.asyncio
     async def test_uses_session_tag(self) -> None:
@@ -201,13 +211,14 @@ class TestConversationMemoryMiddleware:
             middleware = ConversationMemoryMiddleware(config)
             await middleware._ensure_initialized_async()
 
-            async def mock_handler(request: dict) -> dict:
-                return {"content": "Handler response"}
+            async def mock_handler(request: dict) -> ModelResponse:
+                return ModelResponse(result=[AIMessage(content="Handler response")])
 
             request = {"messages": [{"role": "user", "content": "Test"}]}
             result = await middleware.awrap_model_call(request, mock_handler)
 
-            assert result == {"content": "Handler response"}
+            assert hasattr(result, "result")
+            assert result.result[0].content == "Handler response"
 
     @pytest.mark.asyncio
     async def test_raises_on_history_error_without_graceful_degradation(self) -> None:
@@ -231,8 +242,8 @@ class TestConversationMemoryMiddleware:
             middleware = ConversationMemoryMiddleware(config)
             await middleware._ensure_initialized_async()
 
-            async def mock_handler(request: dict) -> dict:
-                return {"content": "Handler response"}
+            async def mock_handler(request: dict) -> ModelResponse:
+                return ModelResponse(result=[AIMessage(content="Handler response")])
 
             request = {"messages": [{"role": "user", "content": "Test"}]}
             with pytest.raises(Exception, match="Redis error"):
@@ -294,15 +305,21 @@ class TestConversationMemoryMiddleware:
 
             seen_messages = []
 
-            async def mock_handler(request: dict) -> dict:
+            async def mock_handler(request: dict) -> ModelResponse:
                 seen_messages.extend(request.get("messages", []))
-                return {"content": "New response"}
+                return ModelResponse(result=[AIMessage(content="New response")])
 
             request = {"messages": [{"role": "user", "content": "Tell me more"}]}
             await middleware.awrap_model_call(request, mock_handler)
 
-            # Context should be injected before the current message
-            assert len(seen_messages) >= 1
+            # Context should be injected before the current message:
+            # SystemMessage (context note) + 2 context messages + 1 user message
+            assert len(seen_messages) == 4
+            # First should be the context note SystemMessage
+            from langchain_core.messages import SystemMessage
+
+            assert isinstance(seen_messages[0], SystemMessage)
+            assert "context from previous" in seen_messages[0].content.lower()
 
     @pytest.mark.asyncio
     async def test_tool_call_passes_through(self) -> None:
@@ -322,6 +339,48 @@ class TestConversationMemoryMiddleware:
         result = await middleware.awrap_tool_call(request, mock_handler)
 
         assert result == {"result": "tool result"}
+
+    @pytest.mark.asyncio
+    async def test_stores_messages_from_model_response(self) -> None:
+        """Test that both user and assistant messages are stored when handler returns ModelResponse."""
+        from langgraph.middleware.redis.conversation_memory import (
+            ConversationMemoryMiddleware,
+        )
+
+        mock_client = AsyncMock()
+        config = ConversationMemoryConfig(redis_client=mock_client)
+
+        with patch(
+            "langgraph.middleware.redis.conversation_memory.SemanticMessageHistory"
+        ) as mock_history_class:
+            mock_history = MagicMock()
+            mock_history.get_relevant = MagicMock(return_value=[])
+            mock_history.add_messages = MagicMock()
+            mock_history_class.return_value = mock_history
+
+            middleware = ConversationMemoryMiddleware(config)
+            await middleware._ensure_initialized_async()
+
+            async def mock_handler(request: dict) -> ModelResponse:
+                return ModelResponse(
+                    result=[AIMessage(content="I'm doing great, thanks!")]
+                )
+
+            request = {"messages": [{"role": "user", "content": "How are you?"}]}
+            result = await middleware.awrap_model_call(request, mock_handler)
+
+            # Verify the response is a ModelResponse with the right content
+            assert hasattr(result, "result")
+            assert result.result[0].content == "I'm doing great, thanks!"
+
+            # Verify both messages were stored
+            assert mock_history.add_messages.call_count == 2
+            user_call = mock_history.add_messages.call_args_list[0]
+            assert user_call[0][0] == [{"role": "user", "content": "How are you?"}]
+            llm_call = mock_history.add_messages.call_args_list[1]
+            assert llm_call[0][0] == [
+                {"role": "llm", "content": "I'm doing great, thanks!"}
+            ]
 
     @pytest.mark.asyncio
     async def test_handles_langchain_messages(self) -> None:


### PR DESCRIPTION
## Summary

- **Fix response content extraction**: `ModelResponse` has `.result` (a `list[BaseMessage]`), not `.content`. The code was using `getattr(response, "content", "")` which always returned `""`, so assistant messages were never stored.
- **Fix context message types**: Context messages were injected as plain dicts, but `ModelRequest.messages` expects LangChain message types. Now returns `SystemMessage`, `HumanMessage`, and `AIMessage` objects.
- **Fix role mismatch**: Assistant messages were stored with role `"assistant"`, but redisvl's `SemanticMessageHistory` expects `"llm"`.
- **Fix tests**: All mock handlers now return `ModelResponse(result=[AIMessage(...)])` instead of plain dicts, which previously masked these bugs. Added new test for explicit message storage verification and multi-turn recall integration test.

## Test plan

- [x] `poetry run pytest tests/test_middleware_conversation_memory.py -vv` — 14 passed
- [x] `poetry run pytest tests/integration/test_middleware_end_to_end.py -vv` — 6 passed
- [x] `poetry run pytest tests/integration/test_middleware_notebook_scenarios.py -vv` — 12 passed
- [x] `make test-all` — 626 passed, 6 skipped