### PR TITLE
chore(tests): suppress third-party deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ filterwarnings = [
     "ignore::DeprecationWarning:testcontainers.redis",
     # Ignore trustcall library's deprecated import (used by langmem)
     "ignore:Importing Send from langgraph.constants is deprecated.*:langgraph.errors.LangGraphDeprecatedSinceV10:trustcall._base",
+    # Ignore PyTorch internal deprecation triggered by sentence-transformers during model loading
+    "ignore::DeprecationWarning:torch.jit._script",
+    # Ignore redisvl internal deprecation in SemanticCache (our code already uses AsyncRedis.from_url directly)
+    "ignore:get_async_redis_connection will become async:DeprecationWarning:redisvl.redis.connection",
 ]
 
 [tool.poetry.scripts]


### PR DESCRIPTION
## Summary
- Suppress 43 deprecation warnings from third-party libraries that clutter test output
- **torch.jit.script_method**: PyTorch internal deprecation triggered by sentence-transformers during model loading — not actionable by us
- **redisvl get_async_redis_connection**: redisvl's own SemanticCache internals — our code already uses `AsyncRedis.from_url()` directly to avoid this

## Test plan
- [x] `make test-all` passes: 627 passed, 6 skipped, **0 warnings**