### PR TITLE
chore(release): bump version to 0.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langgraph-checkpoint-redis"
-version = "0.3.5"
+version = "0.3.6"
 description = "Redis implementation of the LangGraph agent checkpoint saver and store."
 authors = ["Redis Inc. <applied.ai@redis.com>", "Brian Sam-Bodden <bsb@redis.io>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump `langgraph-checkpoint-redis` version from 0.3.5 to 0.3.6

## Test plan

- [x] Version field updated in `pyproject.toml`