### PR TITLE
feat: implement aprune() / prune() with keep_last strategy for interrupt-safe checkpoint pruning

### DIFF
--- a/langgraph/checkpoint/redis/__init__.py
+++ b/langgraph/checkpoint/redis/__init__.py
@@ -1686,6 +1686,122 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
                 pipeline.delete(key)
             pipeline.execute()
 
+    def prune(
+        self,
+        thread_ids: Sequence[str],
+        *,
+        strategy: str = "keep_latest",
+        keep_last: int = 1,
+    ) -> None:
+        """Prune old checkpoints for the given threads, keeping only the most recent.
+
+        Unlike ``delete_thread``, this method retains the N most recent checkpoints
+        and removes only the older ones (along with their associated write keys and
+        key-registry sorted sets).  Checkpoint blobs are intentionally *not* deleted
+        because they are shared across checkpoints via channel versioning.
+
+        Args:
+            thread_ids: Thread IDs whose old checkpoints should be pruned.
+            strategy: Pruning strategy. One of:
+                - ``"keep_latest"``: Keep only the single most-recent checkpoint.
+                - ``"keep_last"``:   Keep the *N* most-recent checkpoints (see
+                  ``keep_last``).  Recommended for multi-tool interrupt chains where
+                  intermediate checkpoints track already-completed tool calls.
+                - ``"delete"``:      Remove *all* checkpoints for the thread.
+            keep_last: Number of recent checkpoints to retain when
+                ``strategy="keep_last"``.  Ignored for other strategies.
+
+        Raises:
+            ValueError: If an unknown strategy is supplied.
+        """
+        if strategy == "delete":
+            keep_n = 0
+        elif strategy == "keep_latest":
+            keep_n = 1
+        elif strategy == "keep_last":
+            keep_n = keep_last
+        else:
+            raise ValueError(
+                f"Unknown pruning strategy: {strategy!r}. "
+                "Valid strategies: 'keep_latest', 'keep_last', 'delete'."
+            )
+
+        for thread_id in thread_ids:
+            storage_safe_thread_id = to_storage_safe_id(thread_id)
+
+            # Fetch all checkpoints for this thread
+            checkpoint_query = FilterQuery(
+                filter_expression=Tag("thread_id") == storage_safe_thread_id,
+                return_fields=["checkpoint_ns", "checkpoint_id"],
+                num_results=10000,
+            )
+            checkpoint_results = self.checkpoints_index.search(checkpoint_query)
+
+            if not checkpoint_results.docs:
+                continue
+
+            # Sort by checkpoint_id descending — ULIDs are lexicographically
+            # time-ordered, so newest checkpoints sort first with no extra parsing.
+            docs_sorted = sorted(
+                checkpoint_results.docs,
+                key=lambda d: getattr(d, "checkpoint_id", ""),
+                reverse=True,
+            )
+
+            to_evict = docs_sorted[keep_n:]
+            if not to_evict:
+                continue
+
+            keys_to_delete = []
+            for doc in to_evict:
+                checkpoint_ns = getattr(doc, "checkpoint_ns", "")
+                checkpoint_id = getattr(doc, "checkpoint_id", "")
+
+                # Evict checkpoint document
+                keys_to_delete.append(
+                    self._make_redis_checkpoint_key_cached(
+                        thread_id, checkpoint_ns, checkpoint_id
+                    )
+                )
+
+                # Evict all write documents for this checkpoint
+                writes_query = FilterQuery(
+                    filter_expression=(
+                        (Tag("thread_id") == storage_safe_thread_id)
+                        & (Tag("checkpoint_id") == checkpoint_id)
+                    ),
+                    return_fields=["checkpoint_ns", "checkpoint_id", "task_id", "idx"],
+                    num_results=10000,
+                )
+                writes_results = self.checkpoint_writes_index.search(writes_query)
+                for wdoc in writes_results.docs:
+                    keys_to_delete.append(
+                        self._make_redis_checkpoint_writes_key(
+                            storage_safe_thread_id,
+                            getattr(wdoc, "checkpoint_ns", ""),
+                            getattr(wdoc, "checkpoint_id", ""),
+                            getattr(wdoc, "task_id", ""),
+                            int(getattr(wdoc, "idx", 0)),
+                        )
+                    )
+
+                # Evict key-registry sorted set for this checkpoint
+                if self._key_registry:
+                    keys_to_delete.append(
+                        self._key_registry.make_write_keys_zset_key(
+                            thread_id, checkpoint_ns, checkpoint_id
+                        )
+                    )
+
+            if self.cluster_mode:
+                for key in keys_to_delete:
+                    self._redis.delete(key)
+            else:
+                pipeline = self._redis.pipeline()
+                for key in keys_to_delete:
+                    pipeline.delete(key)
+                pipeline.execute()
+
 
 __all__ = [
     "__version__",

--- a/langgraph/checkpoint/redis/aio.py
+++ b/langgraph/checkpoint/redis/aio.py
@@ -2075,3 +2075,121 @@ class AsyncRedisSaver(
             for key in keys_to_delete:
                 pipeline.delete(key)
             await pipeline.execute()
+
+    async def aprune(
+        self,
+        thread_ids: Sequence[str],
+        *,
+        strategy: str = "keep_latest",
+        keep_last: int = 1,
+    ) -> None:
+        """Prune old checkpoints for the given threads, keeping only the most recent.
+
+        Unlike ``adelete_thread``, this method retains the N most recent checkpoints
+        and removes only the older ones (along with their associated write keys and
+        key-registry sorted sets).  Checkpoint blobs are intentionally *not* deleted
+        because they are shared across checkpoints via channel versioning.
+
+        Args:
+            thread_ids: Thread IDs whose old checkpoints should be pruned.
+            strategy: Pruning strategy. One of:
+                - ``"keep_latest"``: Keep only the single most-recent checkpoint.
+                - ``"keep_last"``:   Keep the *N* most-recent checkpoints (see
+                  ``keep_last``).  Recommended for multi-tool interrupt chains where
+                  intermediate checkpoints track already-completed tool calls.
+                - ``"delete"``:      Remove *all* checkpoints for the thread.
+            keep_last: Number of recent checkpoints to retain when
+                ``strategy="keep_last"``.  Ignored for other strategies.
+
+        Raises:
+            ValueError: If an unknown strategy is supplied.
+        """
+        if strategy == "delete":
+            keep_n = 0
+        elif strategy == "keep_latest":
+            keep_n = 1
+        elif strategy == "keep_last":
+            keep_n = keep_last
+        else:
+            raise ValueError(
+                f"Unknown pruning strategy: {strategy!r}. "
+                "Valid strategies: 'keep_latest', 'keep_last', 'delete'."
+            )
+
+        for thread_id in thread_ids:
+            storage_safe_thread_id = to_storage_safe_id(thread_id)
+
+            # Fetch all checkpoints for this thread
+            checkpoint_query = FilterQuery(
+                filter_expression=Tag("thread_id") == storage_safe_thread_id,
+                return_fields=["checkpoint_ns", "checkpoint_id"],
+                num_results=10000,
+            )
+            checkpoint_results = await self.checkpoints_index.search(checkpoint_query)
+
+            if not checkpoint_results.docs:
+                continue
+
+            # Sort by checkpoint_id descending — ULIDs are lexicographically
+            # time-ordered, so newest checkpoints sort first with no extra parsing.
+            docs_sorted = sorted(
+                checkpoint_results.docs,
+                key=lambda d: getattr(d, "checkpoint_id", ""),
+                reverse=True,
+            )
+
+            to_evict = docs_sorted[keep_n:]
+            if not to_evict:
+                continue
+
+            keys_to_delete = []
+            for doc in to_evict:
+                checkpoint_ns = getattr(doc, "checkpoint_ns", "")
+                checkpoint_id = getattr(doc, "checkpoint_id", "")
+
+                # Evict checkpoint document
+                keys_to_delete.append(
+                    self._make_redis_checkpoint_key(
+                        storage_safe_thread_id, checkpoint_ns, checkpoint_id
+                    )
+                )
+
+                # Evict all write documents for this checkpoint
+                writes_query = FilterQuery(
+                    filter_expression=(
+                        (Tag("thread_id") == storage_safe_thread_id)
+                        & (Tag("checkpoint_id") == checkpoint_id)
+                    ),
+                    return_fields=["checkpoint_ns", "checkpoint_id", "task_id", "idx"],
+                    num_results=10000,
+                )
+                writes_results = await self.checkpoint_writes_index.search(
+                    writes_query
+                )
+                for wdoc in writes_results.docs:
+                    keys_to_delete.append(
+                        self._make_redis_checkpoint_writes_key(
+                            storage_safe_thread_id,
+                            getattr(wdoc, "checkpoint_ns", ""),
+                            getattr(wdoc, "checkpoint_id", ""),
+                            getattr(wdoc, "task_id", ""),
+                            int(getattr(wdoc, "idx", 0)),
+                        )
+                    )
+
+                # Evict key-registry sorted set for this checkpoint
+                if self._key_registry:
+                    keys_to_delete.append(
+                        self._key_registry.make_write_keys_zset_key(
+                            thread_id, checkpoint_ns, checkpoint_id
+                        )
+                    )
+
+            if self.cluster_mode:
+                for key in keys_to_delete:
+                    await self._redis.delete(key)
+            else:
+                pipeline = self._redis.pipeline()
+                for key in keys_to_delete:
+                    pipeline.delete(key)
+                await pipeline.execute()

--- a/tests/test_issue_159_aprune_keep_last.py
+++ b/tests/test_issue_159_aprune_keep_last.py
@@ -1,0 +1,296 @@
+"""Integration tests for issue #159 — aprune() / prune() with keep_last strategy.
+
+Tests cover:
+- keep_latest  (keep 1 checkpoint)
+- keep_last=N  (interrupt-safe window)
+- delete       (remove all)
+- invalid strategy raises ValueError
+- empty thread is a no-op
+- other threads are untouched
+- associated writes are removed for evicted checkpoints
+- sync (RedisSaver.prune) and async (AsyncRedisSaver.aprune) variants
+"""
+
+import time
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata
+from ulid import ULID
+
+from langgraph.checkpoint.redis import RedisSaver
+from langgraph.checkpoint.redis.aio import AsyncRedisSaver
+from redisvl.query import FilterQuery
+from redisvl.query.filter import Tag
+
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ulid() -> str:
+    """Return a time-ordered ULID string, with a small sleep to guarantee ordering."""
+    time.sleep(0.002)  # 2 ms gap — enough for distinct millisecond timestamps
+    return str(ULID())
+
+
+def _make_checkpoint(cp_id: str, channel_value: str = "data") -> Checkpoint:
+    return Checkpoint(
+        v=1,
+        id=cp_id,
+        ts="2024-01-01T00:00:00Z",
+        channel_values={"messages": [channel_value]},
+        channel_versions={"messages": "1"},
+        versions_seen={"agent": {"messages": "1"}},
+        pending_sends=[],
+        tasks=[],
+    )
+
+
+def _config(thread_id: str, cp_id: str, ns: str = "") -> RunnableConfig:
+    return {
+        "configurable": {
+            "thread_id": thread_id,
+            "checkpoint_ns": ns,
+            "checkpoint_id": cp_id,
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aprune_keep_latest_removes_older_checkpoints(redis_url: str) -> None:
+    """aprune(keep_latest) retains only the single most-recent checkpoint."""
+    async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
+        thread_id = f"prune-keep-latest-{_make_ulid()}"
+
+        # Store 3 checkpoints in order
+        cp_ids = [_make_ulid() for _ in range(3)]
+        for cp_id in cp_ids:
+            await saver.aput(
+                config=_config(thread_id, cp_id),
+                checkpoint=_make_checkpoint(cp_id),
+                metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                new_versions={"messages": "1"},
+            )
+
+        await saver.aprune([thread_id], strategy="keep_latest")
+
+        # Only the latest (last ULID = highest) should survive
+        latest_cp_id = cp_ids[-1]
+        result = await saver.aget_tuple(_config(thread_id, latest_cp_id))
+        assert result is not None, "Latest checkpoint must be retained"
+
+        # Older two must be gone
+        for old_cp_id in cp_ids[:-1]:
+            result = await saver.aget_tuple(_config(thread_id, old_cp_id))
+            assert result is None, f"Checkpoint {old_cp_id} should have been pruned"
+
+
+@pytest.mark.asyncio
+async def test_aprune_keep_last_n_retains_window(redis_url: str) -> None:
+    """aprune(keep_last, keep_last=N) retains the N most-recent checkpoints."""
+    async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
+        thread_id = f"prune-keep-last-{_make_ulid()}"
+        N = 3
+
+        cp_ids = [_make_ulid() for _ in range(5)]
+        for cp_id in cp_ids:
+            await saver.aput(
+                config=_config(thread_id, cp_id),
+                checkpoint=_make_checkpoint(cp_id),
+                metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                new_versions={"messages": "1"},
+            )
+
+        await saver.aprune([thread_id], strategy="keep_last", keep_last=N)
+
+        # Last N should survive
+        for cp_id in cp_ids[-N:]:
+            result = await saver.aget_tuple(_config(thread_id, cp_id))
+            assert result is not None, f"Checkpoint {cp_id} should be retained"
+
+        # Earlier ones must be evicted
+        for cp_id in cp_ids[:-N]:
+            result = await saver.aget_tuple(_config(thread_id, cp_id))
+            assert result is None, f"Checkpoint {cp_id} should be pruned"
+
+
+@pytest.mark.asyncio
+async def test_aprune_delete_removes_all_checkpoints(redis_url: str) -> None:
+    """aprune(delete) removes every checkpoint for the thread."""
+    async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
+        thread_id = f"prune-delete-{_make_ulid()}"
+        cp_ids = [_make_ulid() for _ in range(4)]
+
+        for cp_id in cp_ids:
+            await saver.aput(
+                config=_config(thread_id, cp_id),
+                checkpoint=_make_checkpoint(cp_id),
+                metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                new_versions={"messages": "1"},
+            )
+
+        await saver.aprune([thread_id], strategy="delete")
+
+        for cp_id in cp_ids:
+            result = await saver.aget_tuple(_config(thread_id, cp_id))
+            assert result is None, f"Checkpoint {cp_id} should have been deleted"
+
+
+@pytest.mark.asyncio
+async def test_aprune_invalid_strategy_raises(redis_url: str) -> None:
+    """aprune raises ValueError for unknown strategy names."""
+    async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
+        with pytest.raises(ValueError, match="Unknown pruning strategy"):
+            await saver.aprune(["any-thread"], strategy="bogus")
+
+
+@pytest.mark.asyncio
+async def test_aprune_empty_thread_is_noop(redis_url: str) -> None:
+    """aprune on a thread with no checkpoints completes without error."""
+    async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
+        await saver.aprune([f"nonexistent-{_make_ulid()}"], strategy="keep_latest")
+
+
+@pytest.mark.asyncio
+async def test_aprune_does_not_affect_other_threads(redis_url: str) -> None:
+    """Pruning one thread must leave a different thread's checkpoints intact."""
+    async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
+        target_thread = f"target-{_make_ulid()}"
+        other_thread = f"other-{_make_ulid()}"
+
+        # Both threads get 3 checkpoints
+        for thread_id in (target_thread, other_thread):
+            for _ in range(3):
+                cp_id = _make_ulid()
+                await saver.aput(
+                    config=_config(thread_id, cp_id),
+                    checkpoint=_make_checkpoint(cp_id),
+                    metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                    new_versions={"messages": "1"},
+                )
+
+        # Only prune the target thread
+        await saver.aprune([target_thread], strategy="keep_latest")
+
+        # Other thread must be fully intact — alist returns all checkpoints
+        other_checkpoints = [
+            c
+            async for c in saver.alist(
+                {"configurable": {"thread_id": other_thread, "checkpoint_ns": ""}}
+            )
+        ]
+        assert len(other_checkpoints) == 3, "Other thread must be untouched"
+
+
+@pytest.mark.asyncio
+async def test_aprune_removes_associated_writes(redis_url: str) -> None:
+    """Writes for evicted checkpoints are deleted; writes for retained ones survive."""
+    async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
+        thread_id = f"prune-writes-{_make_ulid()}"
+
+        cp_ids = [_make_ulid() for _ in range(2)]
+        for i, cp_id in enumerate(cp_ids):
+            cfg = _config(thread_id, cp_id)
+            await saver.aput(
+                config=cfg,
+                checkpoint=_make_checkpoint(cp_id, f"step-{i}"),
+                metadata=CheckpointMetadata(source="input", step=i, writes={}),
+                new_versions={"messages": "1"},
+            )
+            await saver.aput_writes(
+                config=cfg,
+                writes=[("messages", f"write-{i}")],
+                task_id=f"task-{i}",
+            )
+
+        await saver.aprune([thread_id], strategy="keep_latest")
+
+        # Latest checkpoint should still have its writes (pending_writes in tuple)
+        latest_tuple = await saver.aget_tuple(_config(thread_id, cp_ids[-1]))
+        assert latest_tuple is not None, "Latest checkpoint must survive"
+
+        # Evicted checkpoint should be gone entirely
+        evicted_tuple = await saver.aget_tuple(_config(thread_id, cp_ids[0]))
+        assert evicted_tuple is None, "Evicted checkpoint must be gone"
+        
+        # Evicted checkpoint's writes must be gone 
+        evicted_results = await saver.checkpoint_writes_index.search(FilterQuery(
+            Tag("checkpoint_id") == cp_ids[0]
+        ))
+        assert len(evicted_results.docs) == 0, f"Evicted write must be removed"
+
+        # Retained checkpoint's writes must still be accessible
+        retained_results = await saver.checkpoint_writes_index.search(FilterQuery(
+            Tag("checkpoint_id") == cp_ids[-1]
+        ))
+        assert len(retained_results.docs) > 0, "Retained writes must still exist"
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+def test_prune_keep_latest_sync(redis_url: str) -> None:
+    """Sync prune(keep_latest) removes older checkpoints."""
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        thread_id = f"sync-prune-{_make_ulid()}"
+        cp_ids = [_make_ulid() for _ in range(3)]
+
+        for cp_id in cp_ids:
+            saver.put(
+                config=_config(thread_id, cp_id),
+                checkpoint=_make_checkpoint(cp_id),
+                metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                new_versions={"messages": "1"},
+            )
+
+        saver.prune([thread_id], strategy="keep_latest")
+
+        result = saver.get_tuple(_config(thread_id, cp_ids[-1]))
+        assert result is not None, "Latest checkpoint must be retained"
+
+        for old_cp_id in cp_ids[:-1]:
+            result = saver.get_tuple(_config(thread_id, old_cp_id))
+            assert result is None, f"Checkpoint {old_cp_id} should be pruned"
+
+
+def test_prune_invalid_strategy_raises_sync(redis_url: str) -> None:
+    """Sync prune raises ValueError for unknown strategy."""
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        with pytest.raises(ValueError, match="Unknown pruning strategy"):
+            saver.prune(["any"], strategy="nope")
+
+
+def test_prune_keep_last_n_sync(redis_url: str) -> None:
+    """Sync prune(keep_last=N) retains the N most-recent checkpoints."""
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        thread_id = f"sync-keep-last-{_make_ulid()}"
+        N = 2
+        cp_ids = [_make_ulid() for _ in range(4)]
+
+        for cp_id in cp_ids:
+            saver.put(
+                config=_config(thread_id, cp_id),
+                checkpoint=_make_checkpoint(cp_id),
+                metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                new_versions={"messages": "1"},
+            )
+
+        saver.prune([thread_id], strategy="keep_last", keep_last=N)
+
+        for cp_id in cp_ids[-N:]:
+            assert saver.get_tuple(_config(thread_id, cp_id)) is not None
+
+        for cp_id in cp_ids[:-N]:
+            assert saver.get_tuple(_config(thread_id, cp_id)) is None


### PR DESCRIPTION
## Summary

Implements `AsyncRedisSaver.aprune()` and `RedisSaver.prune()`, which previously raised `NotImplementedError`. Adds a `keep_last: int` parameter alongside `strategy` to make pruning safe for multi-tool interrupt chains.

---

## The Problem

Simply keeping only the **latest** checkpoint (`strategy="keep_latest"`) breaks human-in-the-loop flows. When an `AIMessage` contains N tool calls, each raises its own sequential interrupt. LangGraph tracks which tools in the batch have already completed via `checkpoint_write` entries stored under **intermediate** checkpoints. Pruning those intermediate checkpoints before all tool calls resolve causes LangGraph to re-execute already-completed tools on the next resume.

---

## API

```python
# Async
await saver.aprune(
    thread_ids=["thread-1", "thread-2"],
    strategy="keep_last",   # or "keep_latest" / "delete"
    keep_last=20,           # ignored unless strategy="keep_last"
)

# Sync
saver.prune(
    thread_ids=["thread-1"],
    strategy="keep_latest",
)
```

### Strategies

| Strategy | Keeps | Use case |
|---|---|---|
| `keep_latest` | 1 checkpoint | Simple single-tool turns |
| `keep_last` | N checkpoints | Multi-tool interrupt chains (HITL-safe) |
| `delete` | 0 checkpoints | Full thread wipe (same as `adelete_thread` but without blobs) |

**Recommended window for `keep_last`:** `max(10, n_tool_calls * 3 + 5)` — 3 checkpoints per interrupted tool + 5 overhead buffer.

---

## Implementation Details

- Uses `checkpoints_index` / `checkpoint_writes_index` search (consistent with `adelete_thread`)
- Sorts by `checkpoint_id` descending — ULIDs are lexicographically time-ordered, no timestamp parsing needed
- Per evicted checkpoint, deletes:
  - checkpoint document (`checkpoint:{thread_id}:{ns}:{checkpoint_id}`)
  - all associated write documents (`checkpoint_write:*`)
  - key-registry sorted set (`write_keys_zset:*`) if `_key_registry` is active
- Cluster mode handled: individual `DELETE` calls for cluster, pipeline for standalone
- `checkpoint_latest:*` pointers are **not** deleted — they still correctly point to the retained checkpoint

---

## Open Question for Maintainers: Blob Pruning

**Checkpoint blobs (`checkpoint_blob:*`) are intentionally not deleted in this PR.**

Blobs are keyed by `(thread_id, checkpoint_ns, channel, version)` — not by `checkpoint_id`. Multiple checkpoints can reference the same blob version when a channel's value hasn't changed between steps. Naively deleting blobs for evicted checkpoints would silently corrupt retained checkpoints that still reference the same version.

The correct approach requires reference-counting across the pruning boundary:

```
kept_versions   = union of channel_versions dicts from all RETAINED checkpoints
evicted_versions = union of channel_versions dicts from all EVICTED checkpoints
safe_to_delete  = evicted_versions - kept_versions  # set difference
```

This requires an extra read of each retained checkpoint's full document and is meaningfully more complex. We'd like to ship this as a **follow-up PR** once we align on:

1. Is `channel_versions` always a reliable source of truth for blob references, or can blobs be referenced from other fields (e.g. `pending_sends`)?
2. Is there an existing index or reverse-lookup structure we should use rather than reading full checkpoint documents?
3. Any preference on whether blob pruning should be opt-in (e.g. `prune_blobs: bool = False`) to keep the default safe?

---

## Tests

10 integration tests in `tests/test_issue_159_aprune_keep_last.py`, all running against real Redis via TestContainers DockerCompose:

| Test | Covers |
|---|---|
| `test_aprune_keep_latest_removes_older_checkpoints` | `keep_latest` removes all but newest |
| `test_aprune_keep_last_n_retains_window` | `keep_last=N` retains correct window |
| `test_aprune_delete_removes_all_checkpoints` | `delete` wipes everything |
| `test_aprune_invalid_strategy_raises` | `ValueError` on unknown strategy |
| `test_aprune_empty_thread_is_noop` | no-op on thread with no checkpoints |
| `test_aprune_does_not_affect_other_threads` | other threads untouched |
| `test_aprune_removes_associated_writes` | write docs evicted; retained writes survive (two-sided assertion) |
| `test_prune_keep_latest_sync` | sync `RedisSaver.prune` |
| `test_prune_invalid_strategy_raises_sync` | sync `ValueError` |
| `test_prune_keep_last_n_sync` | sync `keep_last=N` |
