### PR TITLE
feat: implement aprune() / prune() with keep_last strategy for interrupt-safe checkpoint pruning (#159)

### DIFF
--- a/langgraph/checkpoint/redis/__init__.py
+++ b/langgraph/checkpoint/redis/__init__.py
@@ -1692,6 +1692,7 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
         thread_ids: Sequence[str],
         *,
         keep_last: int = 1,
+        max_results: int = 10000,
     ) -> None:
         """Prune old checkpoints for the given threads per namespace.
 
@@ -1713,7 +1714,21 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
                 Use ``keep_last=0`` to remove all checkpoints for the thread.
                 For multi-tool interrupt chains, ``max(10, n_tool_calls * 3 + 5)``
                 is a safe heuristic.
+            max_results: Maximum number of checkpoints fetched from the index
+                per thread in a single query.  Threads with more checkpoints
+                than this limit will only have the first ``max_results`` entries
+                considered for pruning.  Raise this value for very long-lived
+                threads.  Defaults to 10 000.
         """
+        # Validate input
+        if not thread_ids:
+            raise ValueError("``thread_ids`` must be a non-empty sequence")
+        if keep_last < 0:
+            raise ValueError(f"``keep_last`` must be >= 0, got {keep_last}")
+        if max_results < 1:
+            raise ValueError(f"``max_results`` must be >= 1, got {max_results}")
+        
+        
         for thread_id in thread_ids:
             storage_safe_thread_id = to_storage_safe_id(thread_id)
 
@@ -1721,7 +1736,7 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
             checkpoint_query = FilterQuery(
                 filter_expression=Tag("thread_id") == storage_safe_thread_id,
                 return_fields=["checkpoint_ns", "checkpoint_id"],
-                num_results=10000,
+                num_results=max_results,
             )
             checkpoint_results = self.checkpoints_index.search(checkpoint_query)
 
@@ -1738,14 +1753,20 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
             # Within each namespace sort newest-first (ULIDs are lex time-ordered)
             # and collect checkpoints that fall outside the keep_last window.
             to_evict = []
-            for ns_docs in by_ns.values():
+            # Track namespaces where every checkpoint is evicted so we can clean
+            # up the checkpoint_latest:{thread}:{ns} pointer key too.
+            fully_evicted_ns: set = set()
+            for ns, ns_docs in by_ns.items():
                 ns_sorted = sorted(
                     ns_docs,
                     key=lambda d: getattr(d, "checkpoint_id", ""),
                     reverse=True,
                 )
-                to_evict.extend(ns_sorted[keep_last:])
-
+                ns_evicted = ns_sorted[keep_last:]
+                to_evict.extend(ns_evicted)
+                if len(ns_evicted) == len(ns_docs): # nothing left in this namespace
+                    fully_evicted_ns.add(ns)
+                    
             if not to_evict:
                 continue
 
@@ -1768,7 +1789,7 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
                         & (Tag("checkpoint_id") == checkpoint_id)
                     ),
                     return_fields=["checkpoint_ns", "checkpoint_id", "task_id", "idx"],
-                    num_results=10000,
+                    num_results=max_results,
                 )
                 writes_results = self.checkpoint_writes_index.search(writes_query)
                 for wdoc in writes_results.docs:
@@ -1790,6 +1811,14 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
                         )
                     )
 
+            # Delete checkpoint_latest pointers for fully_evicted namespaces.
+            # ns values here come from the index and are already storage-safe,
+            # matching the format written by put(): checkpoint-latest:{tid}:{safe_ns}
+            for ns in fully_evicted_ns:
+                keys_to_delete.append(
+                    f"checkpoint_latest:{storage_safe_thread_id}:{ns}"
+                )
+            
             if self.cluster_mode:
                 for key in keys_to_delete:
                     self._redis.delete(key)

--- a/langgraph/checkpoint/redis/aio.py
+++ b/langgraph/checkpoint/redis/aio.py
@@ -2082,6 +2082,7 @@ class AsyncRedisSaver(
         thread_ids: Sequence[str],
         *,
         keep_last: int = 1,
+        max_results: int = 10000,
     ) -> None:
         """Prune old checkpoints for the given threads per namespace.
 
@@ -2103,7 +2104,20 @@ class AsyncRedisSaver(
                 Use ``keep_last=0`` to remove all checkpoints for the thread.
                 For multi-tool interrupt chains, ``max(10, n_tool_calls * 3 + 5)``
                 is a safe heuristic.
+            max_results: Maximum number of checkpoints fetched from the index
+                per thread in a single query.  Threads with more checkpoints
+                than this limit will only have the first ``max_results`` entries
+                considered for pruning.  Raise this value for very long-lived
+                threads.  Defaults to 10 000.
         """
+        # Validate inputs
+        if not thread_ids:
+            raise ValueError("``thread_ids`` must be a non-empty sequence")
+        if keep_last < 0:
+            raise ValueError(f"``keep_last`` must be >= 0, got {keep_last}")
+        if max_results < 1:
+            raise ValueError(f"``max_results`` must be >= 1, got {max_results}")
+        
         for thread_id in thread_ids:
             storage_safe_thread_id = to_storage_safe_id(thread_id)
 
@@ -2111,7 +2125,7 @@ class AsyncRedisSaver(
             checkpoint_query = FilterQuery(
                 filter_expression=Tag("thread_id") == storage_safe_thread_id,
                 return_fields=["checkpoint_ns", "checkpoint_id"],
-                num_results=10000,
+                num_results=max_results,
             )
             checkpoint_results = await self.checkpoints_index.search(checkpoint_query)
 
@@ -2127,14 +2141,20 @@ class AsyncRedisSaver(
 
             # Within each namespace sort newest-first (ULIDs are lex time-ordered)
             # and collect checkpoints that fall outside the keep_last window.
+            # Track namespaces where every checkpoint is evicted so we can clean
+            # up the checkpoint_latest:{thread}:{ns} pointer key too
             to_evict = []
-            for ns_docs in by_ns.values():
+            fully_evicted_ns: set = set()
+            for ns, ns_docs in by_ns.items():
                 ns_sorted = sorted(
                     ns_docs,
                     key=lambda d: getattr(d, "checkpoint_id", ""),
                     reverse=True,
                 )
-                to_evict.extend(ns_sorted[keep_last:])
+                ns_evicted = ns_sorted[keep_last:]
+                to_evict.extend(ns_evicted)
+                if len(ns_evicted) == len(ns_docs): # nothing left in this namespace
+                    fully_evicted_ns.add(ns)
 
             if not to_evict:
                 continue
@@ -2158,7 +2178,7 @@ class AsyncRedisSaver(
                         & (Tag("checkpoint_id") == checkpoint_id)
                     ),
                     return_fields=["checkpoint_ns", "checkpoint_id", "task_id", "idx"],
-                    num_results=10000,
+                    num_results=max_results,
                 )
                 writes_results = await self.checkpoint_writes_index.search(
                     writes_query
@@ -2181,6 +2201,12 @@ class AsyncRedisSaver(
                             thread_id, checkpoint_ns, checkpoint_id
                         )
                     )
+            
+            for ns in fully_evicted_ns:
+                keys_to_delete.append(
+                    f"checkpoint_latest:{storage_safe_thread_id}:{ns}"
+                )
+            
 
             if self.cluster_mode:
                 for key in keys_to_delete:

--- a/langgraph/checkpoint/redis/ashallow.py
+++ b/langgraph/checkpoint/redis/ashallow.py
@@ -958,6 +958,13 @@ class AsyncShallowRedisSaver(BaseRedisSaver[AsyncRedis, AsyncSearchIndex]):
             keep_last: Checkpoints to retain per namespace.  Any value >= 1
                 is a no-op for shallow savers.  Pass ``0`` to delete all.
         """
+        # Validate input 
+        if not thread_ids:
+            raise ValueError(f"``thread_ids`` must be a non-empty sequence")
+        
+        if keep_last < 0:
+            raise ValueError(f"``keep_last`` must be >= 0, got {keep_last}")
+        
         if keep_last >= 1:
             return
         for thread_id in thread_ids:

--- a/langgraph/checkpoint/redis/shallow.py
+++ b/langgraph/checkpoint/redis/shallow.py
@@ -762,28 +762,31 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
         checkpoint_results = self.checkpoints_index.search(checkpoint_query)
 
         # Collect namespaces and checkpoint IDs
-        # checkpoint_ns from the index is storage-safe; convert back to raw form
-        # so that key construction matches what put() used when storing.
+        # The index stores checkpoint_ns in storage-safe form ("" -> "__empty__").
+        # _make_shallow_redis_checkpoint_key_cached() does its own to_storage_safe_str conversion
+        # internally, so it needs the raw namespace.
+        # The wrote_registry / current_checkpoint keys are raw f-strings, so they
+        # need the storage-safe form that was used when those keys were originally written.
         checkpoint_data = []
         for doc in checkpoint_results.docs:
-            checkpoint_ns = from_storage_safe_str(getattr(doc, "checkpoint_ns", ""))
+            safe_ns = getattr(doc, "checkpoint_ns", "") # storage-safe: for f-strings
+            raw_ns = from_storage_safe_str(safe_ns) # raw: for key builder method
             checkpoint_id = getattr(doc, "checkpoint_id", "")
-            checkpoint_data.append((checkpoint_ns, checkpoint_id))
+            checkpoint_data.append((raw_ns, safe_ns, checkpoint_id))
 
         # Delete all checkpoints and related data
         if checkpoint_data:
             with self._redis.pipeline(transaction=False) as pipeline:
-                for checkpoint_ns, checkpoint_id in checkpoint_data:
-                    # Delete the main checkpoint key
+                for raw_ns, safe_ns, checkpoint_id in checkpoint_data:
+                    # Key builder converts internally - pass raw namespace
                     checkpoint_key = self._make_shallow_redis_checkpoint_key_cached(
-                        thread_id, checkpoint_ns
+                        thread_id, raw_ns
                     )
                     pipeline.delete(checkpoint_key)
 
-                    # Delete thread-level write registry and its writes
-                    # Each namespace has its own thread-level registry
+                    # write_registry key was stored with storage-safe ns - use safe_ns here
                     thread_write_registry_key = (
-                        f"write_registry:{thread_id}:{checkpoint_ns}:shallow"
+                        f"write_registry:{thread_id}:{safe_ns}:shallow"
                     )
 
                     # Get all write keys from the thread registry before deleting
@@ -799,13 +802,12 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
                     # Delete the registry itself
                     pipeline.delete(thread_write_registry_key)
 
-                    # Delete the current checkpoint tracker
+                    # Delete the current checkpoint tracker - use safe_ns here
                     current_checkpoint_key = (
-                        f"current_checkpoint:{thread_id}:{checkpoint_ns}:shallow"
+                        f"current_checkpoint:{thread_id}:{safe_ns}:shallow"
                     )
                     pipeline.delete(current_checkpoint_key)
 
-                # Execute all deletions
                 pipeline.execute()
 
     def prune(
@@ -826,6 +828,13 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
             keep_last: Checkpoints to retain per namespace.  Any value >= 1
                 is a no-op for shallow savers.  Pass ``0`` to delete all.
         """
+        # Validate input 
+        if not thread_ids:
+            raise ValueError(f"``thread_ids`` must be a non-empty sequence")
+        
+        if keep_last < 0:
+            raise ValueError(f"``keep_last`` must be >= 0, got {keep_last}")
+        
         if keep_last >= 1:
             return
         for thread_id in thread_ids:

--- a/tests/test_issue_159_aprune_keep_last.py
+++ b/tests/test_issue_159_aprune_keep_last.py
@@ -427,3 +427,303 @@ def test_shallow_prune_keep_last_0_deletes_all(redis_url: str) -> None:
 
         result = saver.get_tuple(_config(thread_id, cp_id))
         assert result is None, "Shallow checkpoint must be deleted with keep_last=0"
+
+  # ---------------------------------------------------------------------------
+  # Validation tests
+  # ---------------------------------------------------------------------------
+  
+def test_prune_negative_keep_last_raises(redis_url: str) -> None:
+    """prune(keep_last=-1) must raise ValueError immediately."""
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        with pytest.raises(ValueError, match="keep_last"):
+            saver.prune(["any-thread"], keep_last=-1)
+            
+@pytest.mark.asyncio
+async def test_aprune_negative_keep_last_raises(redis_url: str) -> None:
+    """aprune(keep_last=-1) must raise ValueError immediately.
+
+    Args:
+        redis_url (str): Redis Connection URL
+    """
+    async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
+        with pytest.raises(ValueError, match="keep_last"):
+            await saver.aprune(["any-thread"], keep_last=-1)
+            
+            
+  # ---------------------------------------------------------------------------
+  # Sync coverage
+  # ---------------------------------------------------------------------------
+  
+def test_prune_per_namespace_isolation_sync(redis_url: str) -> None:
+    """Sync prune: keep_last applied independently per namespace."""
+    with RedisSaver.from_conn_string(redis_url=redis_url) as saver:
+        saver.setup()
+        thread_id = f"sync-ns-{_make_ulid()}"
+        root_ids = [_make_ulid() for _ in range(3)]
+        sub_ids = [_make_ulid() for _ in range(3)]
+        
+        for cp_id in root_ids:
+            saver.put(
+                config=_config(thread_id, cp_id, ""),
+                checkpoint=_make_checkpoint(cp_id=cp_id),
+                metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                new_versions={"messages": "1"},
+            )
+        for cp_id in sub_ids:
+            saver.put(
+                config=_config(thread_id, cp_id, "subgraph:0"),
+                checkpoint=_make_checkpoint(cp_id=cp_id),
+                metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                new_versions={"messages": "1"},
+            )
+            
+        saver.prune([thread_id], keep_last=1)
+        
+        assert saver.get_tuple(_config(thread_id, root_ids[-1], "")) is not None
+        for cp_id in root_ids[:-1]:
+            assert saver.get_tuple(_config(thread_id, cp_id, "")) is None
+            
+        assert saver.get_tuple(_config(thread_id, sub_ids[-1], "subgraph:0")) is not None
+        for cp_id in sub_ids[:-1]:
+            assert saver.get_tuple(_config(thread_id, cp_id, "subgraph:0")) is None
+            
+
+def test_prune_removes_associated_writes_sync(redis_url: str) -> None:
+    """Sync prune: writes for evicted checkpoints deleted; retained writes survive."""
+    with RedisSaver.from_conn_string(redis_url=redis_url) as saver:
+        saver.setup()
+        thread_id = f"sync-writes-{_make_ulid()}"
+        cp_ids = [_make_ulid() for _ in range(2)]
+        
+        for i, cp_id in enumerate(cp_ids):
+            cfg = _config(thread_id, cp_id)
+            saver.put(
+                config=cfg,
+                checkpoint=_make_checkpoint(cp_id, f"step-{i}"),
+                metadata=CheckpointMetadata(source="input", step=i, writes={}),
+                new_versions={"messages": "1"},
+            )
+            saver.put_writes(
+                config=cfg,
+                writes=[("messages", f"write-{i}")],
+                task_id=f"task-{i}",
+            )
+        
+        saver.prune([thread_id], keep_last=1)
+        
+        assert saver.get_tuple(_config(thread_id, cp_ids[-1])) is not None
+        assert saver.get_tuple(_config(thread_id, cp_ids[0])) is None
+        
+        evicted = saver.checkpoint_writes_index.search(
+            FilterQuery(
+                Tag("checkpoint_id") == cp_ids[0]
+            )
+        )
+        assert len(evicted.docs) == 0, "Evicted writes must be removed"
+        
+        retained = saver.checkpoint_writes_index.search(
+            FilterQuery(
+                Tag("checkpoint_id") == cp_ids[-1]
+            )
+        )
+        assert len(retained.docs) > 0, "Retained writes must survive"
+        
+        
+def test_prune_empty_thread_is_noop_sync(redis_url: str) -> None:
+    """Sync prune on a thread with no checkpoints completes without error."""
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        saver.prune([f"nonexistent-{_make_ulid()}"])
+        
+def test_prune_does_not_affect_other_threads_sync(redis_url: str) -> None:
+    """Sync prune: pruning one thread leaves another thread's checkpoints intact."""
+    with RedisSaver.from_conn_string(redis_url) as saver:
+          saver.setup()
+          target = f"sync-target-{_make_ulid()}"
+          other = f"sync-other-{_make_ulid()}"
+
+          for thread_id in (target, other):
+              for _ in range(3):
+                  cp_id = _make_ulid()
+                  saver.put(
+                      config=_config(thread_id, cp_id),
+                      checkpoint=_make_checkpoint(cp_id),
+                      metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                      new_versions={"messages": "1"},
+                  )
+
+          saver.prune([target], keep_last=1)
+
+          other_checkpoints = list(
+              saver.list({"configurable": {"thread_id": other, "checkpoint_ns": ""}})
+          )
+          assert len(other_checkpoints) == 3, "Other thread must be untouched"
+          
+          
+def test_prune_multiple_thread_ids_sync(redis_url: str) -> None:
+    """Sync prune: pruning multiple thread_ids in one call works correctly."""
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        threads = [f"multi-{_make_ulid()}" for _ in range(2)]
+        all_cp_ids = {}
+        
+        for thread_id in threads:
+            cp_ids = [_make_ulid() for _ in range(3)]
+            all_cp_ids[thread_id] = cp_ids
+            for cp_id in cp_ids:
+                saver.put(
+                    config=_config(thread_id, cp_id),
+                    checkpoint=_make_checkpoint(cp_id),
+                    metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                    new_versions={"messages": "1"},
+                )
+                
+        saver.prune(threads, keep_last=1)
+        
+        for thread_id, cp_ids in all_cp_ids.items():
+            assert saver.get_tuple(_config(thread_id, cp_ids[-1])) is not None
+            for old_id in cp_ids[:-1]:
+                assert saver.get_tuple(_config(thread_id, old_id)) is None
+                
+def test_prune_keep_last_greater_than_total_is_noop_sync(redis_url: str) -> None:
+    """Sync prune: keep_last > total checkpoints should not delete anything."""
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        thread_id = f"sync-noop-{_make_ulid()}"
+        cp_ids = [_make_ulid() for _ in range(2)]
+        
+        for cp_id in cp_ids:
+            saver.put(
+                config=_config(thread_id, cp_id),
+                checkpoint=_make_checkpoint(cp_id),
+                metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                new_versions={"messages": "1"},
+            )
+
+        saver.prune([thread_id], keep_last=100) # way more then 2 stored
+        
+        for cp_id in cp_ids:
+            assert saver.get_tuple(_config(thread_id, cp_id)) is not None, (
+                f"All checkpoints must survive when keep_last > total: {cp_id}"
+            )
+            
+def test_prune_then_continue_sync(redis_url: str) -> None:
+    """Sync: after pruning, putting new checkpoints continues working correctly."""
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        thread_id = f"sync-continue-{_make_ulid()}"
+        
+        # Write some checkpoints, then prune them all
+        for _ in range(10):
+            cp_id = _make_ulid()
+            saver.put(
+                config=_config(thread_id, cp_id),
+                checkpoint=_make_checkpoint(cp_id),
+                metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                new_versions={"messages": "1"},
+            )
+        
+        saver.prune([thread_id], keep_last=0)
+        
+        # Now write a fresh checkpoint — saver must still work
+        new_cp_id = _make_ulid()
+        saver.put(
+            config=_config(thread_id, new_cp_id),
+            checkpoint=_make_checkpoint(new_cp_id),
+            metadata=CheckpointMetadata(source="input", step=10, writes={}),
+            new_versions={"messages": "2"},
+        )
+
+        result = saver.get_tuple(_config(thread_id, new_cp_id))
+        assert result is not None, "New checkpoint after prune must be retrievable"
+        
+        
+        
+# ---------------------------------------------------------------------------
+# Key registry (write_keys_zset) cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_prune_cleans_write_keys_zset_for_evicted_checkpoints(redis_url: str) -> None:
+    """prune() must delete write_keys_zset entries for evicted checkpoints.
+
+    The key registry maintains a sorted set per checkpoint that tracks all
+    write keys for that checkpoint. Evicting a checkpoint without cleaning
+    its zset leaks the sorted set in Redis indefinitely.
+    """
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        thread_id = f"sync-zset-{_make_ulid()}"
+
+        cp_ids = [_make_ulid() for _ in range(2)]
+        for i, cp_id in enumerate(cp_ids):
+            cfg = _config(thread_id, cp_id)
+            saver.put(
+                config=cfg,
+                checkpoint=_make_checkpoint(cp_id, f"step-{i}"),
+                metadata=CheckpointMetadata(source="input", step=i, writes={}),
+                new_versions={"messages": "1"},
+            )
+            # put_writes populates the key registry zset for this checkpoint
+            saver.put_writes(
+                config=cfg,
+                writes=[("messages", f"write-{i}")],
+                task_id=f"task-{i}",
+            )
+
+        # Both zsets must exist before pruning
+        assert saver._key_registry is not None, "Key registry must be initialised by setup()"
+        evicted_zset = saver._key_registry.make_write_keys_zset_key(thread_id, "", cp_ids[0])
+        retained_zset = saver._key_registry.make_write_keys_zset_key(thread_id, "", cp_ids[-1])
+        assert saver._redis.exists(evicted_zset), "Evicted zset must exist before prune"
+        assert saver._redis.exists(retained_zset), "Retained zset must exist before prune"
+
+        saver.prune([thread_id], keep_last=1)
+
+        # Evicted checkpoint's zset must be gone
+        assert not saver._redis.exists(evicted_zset), (
+            "write_keys_zset for evicted checkpoint must be deleted"
+        )
+        # Retained checkpoint's zset must still be there
+        assert saver._redis.exists(retained_zset), (
+            "write_keys_zset for retained checkpoint must survive"
+        )
+
+
+# ---------------------------------------------------------------------------
+# checkpoint_latest pointer cleanup
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_prune_keep_last_0_cleans_checkpoint_latest(redis_url: str) -> None:
+    """aprune(keep_last=0) must delete checkpoint_latest pointer keys.
+
+    Args:
+        redis_url (str): Redis Client
+    """
+    async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
+        thread_id = f"latest-ptr-{_make_ulid()}"
+        from langgraph.checkpoint.redis.util import to_storage_safe_id, to_storage_safe_str
+        
+        cp_id = _make_ulid()
+        await saver.aput(
+            config=_config(thread_id, cp_id),
+            checkpoint=_make_checkpoint(cp_id),
+            metadata=CheckpointMetadata(source="input", step=0, writes={}),
+            new_versions={"messages": "1"},
+        )
+        
+        safe_tid = to_storage_safe_id(thread_id)
+        safe_ns = to_storage_safe_str("") # root namespace -> "__empty__"
+        pointer_key = f"checkpoint_latest:{safe_tid}:{safe_ns}"
+        
+        # Pointer must exist before pruning 
+        assert await saver._redis.exists(pointer_key)
+        
+        await saver.aprune([thread_id], keep_last=0)
+        
+        # Pointer must be gone after full eviction 
+        assert not await saver._redis.exists(pointer_key), ("checkpoint_latest pointer must be cleaned up when keep_last=0")
+        
+        


### PR DESCRIPTION
## Summary

Closes #159

Implements `AsyncRedisSaver.aprune()` and `RedisSaver.prune()` — previously raising `NotImplementedError` — with a `keep_last: int` parameter for interrupt-safe checkpoint pruning.

---

## The Problem

`AsyncRedisSaver` creates a new checkpoint after every agent step. For threads with many turns and multi-tool interrupts this produces unbounded Redis growth. The fix seems obvious — call `aprune()` — but it raised `NotImplementedError`.

### The non-obvious danger: multi-tool interrupt chains

Simply keeping only the latest checkpoint breaks human-in-the-loop flows. When an `AIMessage` contains N tool calls, each raises its own sequential interrupt. LangGraph tracks which tools in the batch have already completed via `checkpoint_write` entries stored under **intermediate** checkpoints. Pruning those before all tool calls resolve causes LangGraph to re-execute already-completed tools on resume — producing duplicate messages, duplicate task creation, duplicate sends.

---

## API

```python
# Async
await saver.aprune(["thread-1", "thread-2"], keep_last=20)

# Sync
saver.prune(["thread-1"], keep_last=1)
```

| `keep_last` | Behaviour |
|---|---|
| `1` (default) | Keep only the most-recent checkpoint per namespace |
| `N` | Keep the N most-recent checkpoints per namespace — safe for multi-tool interrupt chains |
| `0` | Remove all checkpoints for the thread |

**Recommended heuristic for HITL flows:** `keep_last = max(10, n_tool_calls * 3 + 5)`

---

## Implementation Details

- **Simplified API** — no `strategy` string parameter; `keep_last` alone covers all cases (`0` = delete, `1` = keep latest, `N` = keep window). This avoids redundancy and keeps the signature future-compatible without a companion PR to `langchain-ai/langgraph`.
- **Per-namespace pruning** — checkpoints are grouped by `checkpoint_ns` before sorting. Each namespace (root `""` and subgraph namespaces) is an independent chain, so `keep_last` is applied within each independently. A global sort would have silently wiped entire subgraph namespaces.
- **ULID-ordered sort** — `checkpoint_id` is a ULID, which is lexicographically time-ordered. Newest-first sort requires no timestamp parsing.
- **Uses existing index infrastructure** — consistent with `adelete_thread` (`checkpoints_index`, `checkpoint_writes_index`).
- **Per evicted checkpoint deletes:** checkpoint document + all write documents + key-registry zset (if `_key_registry` active).
- **Cluster mode handled** — individual `DELETE` per key for cluster, pipeline for standalone.
- **`checkpoint_latest:*` pointers not deleted** — they still correctly point to the retained checkpoint.

---

## Open Question: Blob Pruning

**Checkpoint blobs (`checkpoint_blob:*`) are intentionally not deleted in this PR.**

Blobs are keyed by `(thread_id, checkpoint_ns, channel, version)` — not by `checkpoint_id`. Multiple checkpoints can reference the same blob version when a channel's value hasn't changed between steps. Naively deleting blobs for evicted checkpoints would silently corrupt retained checkpoints that still reference the same version.

The safe algorithm requires a reference-counting pass across the pruning boundary:

```
kept_refs    = union of channel_versions from all RETAINED checkpoints
evicted_refs = union of channel_versions from all EVICTED checkpoints
safe_to_del  = evicted_refs - kept_refs
```

This needs an extra read of each retained checkpoint's full document and is meaningfully more complex. Happy to ship it as a follow-up PR once we align on:

1. Is `channel_versions` the complete source of blob references, or can blobs be referenced from other fields (e.g. `pending_sends`)?
2. Is there an existing reverse-lookup structure to use instead of reading full checkpoint docs?
3. Any preference on `prune_blobs: bool = False` as an opt-in flag to keep the default safe?

---

## Tests

10 integration tests in `tests/test_issue_159_aprune_keep_last.py`, all running against real Redis via TestContainers DockerCompose (`redis/redis-stack-server:latest`):

| Test | Covers |
|---|---|
| `test_aprune_keep_last_1_removes_older_checkpoints` | `keep_last=1` keeps only newest |
| `test_aprune_keep_last_n_retains_window` | `keep_last=N` retains correct window |
| `test_aprune_keep_last_0_removes_all_checkpoints` | `keep_last=0` wipes everything |
| `test_aprune_per_namespace_isolation` | `keep_last` applied independently per namespace |
| `test_aprune_empty_thread_is_noop` | no-op on thread with no checkpoints |
| `test_aprune_does_not_affect_other_threads` | other threads untouched |
| `test_aprune_removes_associated_writes` | write docs evicted; retained writes survive (two-sided assertion) |
| `test_prune_keep_last_1_sync` | sync `RedisSaver.prune` |
| `test_prune_keep_last_n_sync` | sync `keep_last=N` |
| `test_prune_keep_last_0_sync` | sync `keep_last=0` |
