### PR TITLE
refactor(middleware): add SQL-inspired cache key design and MCP-style…

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,10 +444,24 @@ result = await agent.ainvoke({"messages": [HumanMessage(content="Calculate 25 * 
 
 ### Tool Cacheability
 
-Control which tools are cached using LangChain's native metadata:
+The tool cache uses a priority chain (inspired by SQL function volatility and MCP `ToolAnnotations`) to decide whether a tool call should be cached. The checks are evaluated in order — the first match wins:
+
+| Priority | Check | Result |
+|----------|-------|--------|
+| 1 | `metadata["cacheable"]` is set | Use its boolean value (highest priority) |
+| 2 | `metadata["destructive"] == True` | Never cache |
+| 3 | `metadata["volatile"] == True` | Never cache |
+| 4 | `metadata["read_only"] and metadata["idempotent"]` | Cache |
+| 5 | Tool name matches a side-effect prefix | Never cache |
+| 6 | Call args contain a volatile arg name | Never cache |
+| 7 | Config whitelist / blacklist | Existing fallback |
+
+#### Tool Metadata
+
+Control cacheability per-tool using LangChain's native metadata:
 
 ```python
-# Option 1: Set metadata after @tool decoration
+# Explicit cacheable flag (priority 1 — overrides everything)
 @tool
 def search(query: str) -> str:
     """Search the web."""
@@ -455,7 +469,29 @@ def search(query: str) -> str:
 
 search.metadata = {"cacheable": True}
 
-# Option 2: Use StructuredTool with metadata
+# MCP-style annotations (priorities 2–4)
+@tool
+def send_email(to: str, body: str) -> str:
+    """Send an email."""
+    return smtp_send(to, body)
+
+send_email.metadata = {"destructive": True}  # Never cached
+
+@tool
+def get_exchange_rate(pair: str) -> str:
+    """Get live exchange rate."""
+    return fetch_rate(pair)
+
+get_exchange_rate.metadata = {"volatile": True}  # Never cached
+
+@tool
+def lookup_zip(code: str) -> str:
+    """Look up a ZIP code."""
+    return zip_db.get(code)
+
+lookup_zip.metadata = {"read_only": True, "idempotent": True}  # Cached
+
+# StructuredTool with metadata
 from langchain_core.tools import StructuredTool
 
 get_weather = StructuredTool.from_function(
@@ -465,6 +501,56 @@ get_weather = StructuredTool.from_function(
     metadata={"cacheable": False},  # Real-time data
 )
 ```
+
+#### Advanced Cache Key Configuration
+
+`ToolCacheConfig` supports three opt-in fields for fine-grained cache key control. All default to `None` (disabled), so existing behavior is unchanged.
+
+```python
+from langgraph.middleware.redis import (
+    ToolResultCacheMiddleware,
+    ToolCacheConfig,
+    DEFAULT_VOLATILE_ARG_NAMES,
+    DEFAULT_SIDE_EFFECT_PREFIXES,
+)
+
+tool_cache = ToolResultCacheMiddleware(
+    ToolCacheConfig(
+        redis_url="redis://localhost:6379",
+        name="tool_cache",
+        ttl_seconds=1800,
+
+        # --- Volatile arg names (priority 6) ---
+        # Tool calls containing these arg names at any nesting depth
+        # are never cached. Useful for temporal arguments.
+        # Use the built-in defaults or provide your own set.
+        volatile_arg_names=DEFAULT_VOLATILE_ARG_NAMES,
+        # DEFAULT_VOLATILE_ARG_NAMES includes:
+        #   "timestamp", "current_time", "now", "date",
+        #   "today", "current_date", "current_timestamp"
+
+        # --- Ignored arg names ---
+        # These arg names are stripped from the cache key before
+        # serialization. Two calls differing only in ignored args
+        # will share the same cache entry.
+        ignored_arg_names={"request_id", "trace_id", "correlation_id"},
+
+        # --- Side-effect prefixes (priority 5) ---
+        # Tool names starting with these prefixes are never cached.
+        # Use the built-in defaults or provide your own tuple.
+        side_effect_prefixes=DEFAULT_SIDE_EFFECT_PREFIXES,
+        # DEFAULT_SIDE_EFFECT_PREFIXES includes:
+        #   "send_", "delete_", "create_", "update_", "remove_",
+        #   "write_", "post_", "put_", "patch_"
+    )
+)
+```
+
+**Volatile arg names** — When a tool call's arguments contain a key matching one of these names (checked recursively at any nesting depth), the call is never cached. This prevents stale results for time-dependent queries like `{"query": "weather", "timestamp": 1709827200}`.
+
+**Ignored arg names** — Per-request noise like `request_id` or `trace_id` inflates cache misses without affecting the tool's output. Stripping them from the cache key means two otherwise-identical calls will share a cache entry regardless of their tracking IDs.
+
+**Side-effect prefixes** — Tools whose names start with mutating prefixes (e.g., `send_email`, `delete_record`, `create_user`) are never cached, since their results represent actions that should always execute. This can be overridden per-tool with `metadata["cacheable"] = True`.
 
 ### Middleware Composition
 

--- a/docs/design/tool-caching.md
+++ b/docs/design/tool-caching.md
@@ -1,0 +1,170 @@
+# Tool Result Caching: Design Document
+
+## Problem Statement
+
+The `ToolResultCacheMiddleware` previously used `redisvl.SemanticCache` with vector embeddings
+to cache tool call results. This was architecturally wrong: tool caching is **deterministic** --
+the same tool called with the same arguments always produces the same result. Semantic similarity
+(vector distance) is the wrong abstraction for this use case.
+
+### Why Semantic Similarity Fails for Tool Caching
+
+Vector embeddings map text into a high-dimensional space where "similar meaning" maps to nearby
+points. This works well for natural language (LLM prompts/responses), but creates false cache
+hits for tool calls:
+
+- `get_app_details(app_name="SOMEAPP")` and `get_app_details(app_name="SOMEAPP2")` produce
+  nearly identical embeddings, but return completely different results.
+- `search(query="redis", page=1)` and `search(query="redis", page=2)` are semantically
+  similar but return different data.
+- `lookup(entity="ProjectAlpha")` vs `lookup(entity="ProjectAlpha2")` -- the vector distance
+  is below any reasonable threshold.
+
+Tool caching needs **exact match**: same tool + same args = cache hit. Different args (even
+slightly different) = cache miss.
+
+### When Semantic Caching IS Appropriate
+
+Semantic caching remains correct for **LLM response caching** (`SemanticCacheMiddleware`),
+where the goal is to return a cached response for a semantically similar *user prompt*.
+"What is Python?" and "Tell me about the Python language" are genuinely similar queries
+that can share a cached response.
+
+## Reference Implementations
+
+### FastMCP CachingMiddleware
+
+The [FastMCP CachingMiddleware](https://github.com/jlowin/fastmcp/blob/main/src/fastmcp/server/middleware/caching.py)
+uses exact key-value lookup:
+
+```python
+cache_key = f"{tool_name}:{json.dumps(args, sort_keys=True)}"
+cached = self._cache.get(cache_key)
+```
+
+This is the correct approach: deterministic, no vectorizer needed, no false hits.
+
+### MCP ToolAnnotations Spec
+
+The [MCP specification](https://modelcontextprotocol.io/legacy/concepts/tools) defines
+tool annotations that signal cacheability:
+
+- `readOnlyHint` -- tool does not modify state
+- `destructiveHint` -- tool performs destructive operations
+- `idempotentHint` -- calling multiple times with same args has same effect
+- `openWorldHint` -- tool interacts with external entities
+
+Our cacheability decision chain maps these concepts to metadata fields.
+
+### Known Pitfalls
+
+- [promptfoo cache key bug](https://github.com/promptfoo/promptfoo/issues/7467):
+  cache key must include full tool config, not just args
+- [OpenAI MCP stale caching](https://community.openai.com/t/agent-builder-mcp-calls-will-cache-invalid-endpoints-even-though-they-may-be-valid-later-preventing-you-from-using-them/1368481):
+  caching tool results incorrectly leads to stale data
+
+## Cache Key Design
+
+### SQL Cache Analogy
+
+Think of tool caching like a database table:
+
+| Concept | SQL Analogy | Tool Cache |
+|---------|------------|------------|
+| Tool name | Table name | `search` |
+| Arg keys | Column names | `query`, `page` |
+| Arg values | Row values | `"redis"`, `1` |
+| Cache key | Primary key | `toolcache:search:{"page": 1, "query": "redis"}` |
+
+### Key Format
+
+```
+{config.name}:{tool_name}:{sorted_json_args}
+```
+
+Where `sorted_json_args = json.dumps(effective_args, sort_keys=True)`.
+
+### Key Normalization
+
+1. **Sort keys**: `json.dumps(args, sort_keys=True)` ensures `{"b": 2, "a": 1}` and
+   `{"a": 1, "b": 2}` produce the same key.
+2. **Strip ignored args**: Remove `request_id`, `trace_id`, etc. before key generation.
+3. **Volatile arg detection**: If args contain volatile names (`timestamp`, `now`, etc.),
+   skip caching entirely rather than producing non-deterministic keys.
+
+## Cacheability Decision Chain
+
+Before looking up or storing a cache entry, the middleware evaluates whether the tool
+call is cacheable. The priority chain (highest to lowest):
+
+```
+1. metadata["cacheable"]           -- explicit override (highest priority)
+2. metadata["destructive"] = True  -- never cache
+3. metadata["volatile"] = True     -- never cache
+4. metadata["read_only"] + ["idempotent"] = True -- cache
+5. Side-effect prefix match        -- never cache (send_, delete_, create_, ...)
+6. Volatile arg name in args       -- never cache (timestamp, now, date, ...)
+7. Config whitelist / blacklist    -- fallback
+```
+
+## Example Scenarios
+
+### Correct Caching
+
+```python
+# First call: cache miss, executes tool, stores result
+await cache.awrap_tool_call(
+    ToolCallRequest(tool_call={"name": "search", "args": {"q": "redis"}, "id": "c1"}, ...),
+    handler
+)
+# key = "toolcache:search:{\"q\": \"redis\"}"
+# Result stored: "Found 42 results for redis"
+
+# Second call: exact same args, cache hit
+await cache.awrap_tool_call(
+    ToolCallRequest(tool_call={"name": "search", "args": {"q": "redis"}, "id": "c2"}, ...),
+    handler
+)
+# key = "toolcache:search:{\"q\": \"redis\"}"  -- exact match, returns cached result
+```
+
+### Correct Cache Miss
+
+```python
+# Different args produce different keys -- no false hit
+await cache.awrap_tool_call(
+    ToolCallRequest(tool_call={"name": "search", "args": {"q": "redis", "page": 1}, "id": "c1"}, ...),
+    handler
+)
+# key = "toolcache:search:{\"page\": 1, \"q\": \"redis\"}"
+
+await cache.awrap_tool_call(
+    ToolCallRequest(tool_call={"name": "search", "args": {"q": "redis", "page": 2}, "id": "c2"}, ...),
+    handler
+)
+# key = "toolcache:search:{\"page\": 2, \"q\": \"redis\"}"  -- different key, cache miss
+```
+
+### Ignored Args (Cache Hit)
+
+```python
+config = ToolCacheConfig(ignored_arg_names={"request_id"})
+
+# These two calls share a cache entry because request_id is stripped
+# key = "toolcache:search:{\"q\": \"redis\"}" for both
+await cache.awrap_tool_call({"tool_name": "search", "args": {"q": "redis", "request_id": "r1"}}, handler)
+await cache.awrap_tool_call({"tool_name": "search", "args": {"q": "redis", "request_id": "r2"}}, handler)
+```
+
+## Implementation
+
+The tool cache uses direct Redis `GET`/`SET` operations instead of `SemanticCache`:
+
+- **Store**: `SET key serialized_result [EX ttl]`
+- **Lookup**: `GET key` -- exact match, no vector similarity
+- **No vectorizer needed** -- the `vectorizer` and `distance_threshold` fields on
+  `ToolCacheConfig` are kept for backward compatibility but ignored.
+
+The semantic cache (`SemanticCacheMiddleware`) continues to use `redisvl.SemanticCache`
+with vector embeddings, as semantic similarity is the correct abstraction for LLM
+response caching.

--- a/langgraph/checkpoint/redis/__init__.py
+++ b/langgraph/checkpoint/redis/__init__.py
@@ -1727,8 +1727,7 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
             raise ValueError(f"``keep_last`` must be >= 0, got {keep_last}")
         if max_results < 1:
             raise ValueError(f"``max_results`` must be >= 1, got {max_results}")
-        
-        
+
         for thread_id in thread_ids:
             storage_safe_thread_id = to_storage_safe_id(thread_id)
 
@@ -1764,9 +1763,9 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
                 )
                 ns_evicted = ns_sorted[keep_last:]
                 to_evict.extend(ns_evicted)
-                if len(ns_evicted) == len(ns_docs): # nothing left in this namespace
+                if len(ns_evicted) == len(ns_docs):  # nothing left in this namespace
                     fully_evicted_ns.add(ns)
-                    
+
             if not to_evict:
                 continue
 
@@ -1818,7 +1817,7 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
                 keys_to_delete.append(
                     f"checkpoint_latest:{storage_safe_thread_id}:{ns}"
                 )
-            
+
             if self.cluster_mode:
                 for key in keys_to_delete:
                     self._redis.delete(key)

--- a/langgraph/checkpoint/redis/aio.py
+++ b/langgraph/checkpoint/redis/aio.py
@@ -2117,7 +2117,7 @@ class AsyncRedisSaver(
             raise ValueError(f"``keep_last`` must be >= 0, got {keep_last}")
         if max_results < 1:
             raise ValueError(f"``max_results`` must be >= 1, got {max_results}")
-        
+
         for thread_id in thread_ids:
             storage_safe_thread_id = to_storage_safe_id(thread_id)
 
@@ -2153,7 +2153,7 @@ class AsyncRedisSaver(
                 )
                 ns_evicted = ns_sorted[keep_last:]
                 to_evict.extend(ns_evicted)
-                if len(ns_evicted) == len(ns_docs): # nothing left in this namespace
+                if len(ns_evicted) == len(ns_docs):  # nothing left in this namespace
                     fully_evicted_ns.add(ns)
 
             if not to_evict:
@@ -2180,9 +2180,7 @@ class AsyncRedisSaver(
                     return_fields=["checkpoint_ns", "checkpoint_id", "task_id", "idx"],
                     num_results=max_results,
                 )
-                writes_results = await self.checkpoint_writes_index.search(
-                    writes_query
-                )
+                writes_results = await self.checkpoint_writes_index.search(writes_query)
                 for wdoc in writes_results.docs:
                     keys_to_delete.append(
                         self._make_redis_checkpoint_writes_key(
@@ -2201,12 +2199,11 @@ class AsyncRedisSaver(
                             thread_id, checkpoint_ns, checkpoint_id
                         )
                     )
-            
+
             for ns in fully_evicted_ns:
                 keys_to_delete.append(
                     f"checkpoint_latest:{storage_safe_thread_id}:{ns}"
                 )
-            
 
             if self.cluster_mode:
                 for key in keys_to_delete:

--- a/langgraph/checkpoint/redis/ashallow.py
+++ b/langgraph/checkpoint/redis/ashallow.py
@@ -958,13 +958,13 @@ class AsyncShallowRedisSaver(BaseRedisSaver[AsyncRedis, AsyncSearchIndex]):
             keep_last: Checkpoints to retain per namespace.  Any value >= 1
                 is a no-op for shallow savers.  Pass ``0`` to delete all.
         """
-        # Validate input 
+        # Validate input
         if not thread_ids:
             raise ValueError(f"``thread_ids`` must be a non-empty sequence")
-        
+
         if keep_last < 0:
             raise ValueError(f"``keep_last`` must be >= 0, got {keep_last}")
-        
+
         if keep_last >= 1:
             return
         for thread_id in thread_ids:

--- a/langgraph/checkpoint/redis/shallow.py
+++ b/langgraph/checkpoint/redis/shallow.py
@@ -769,8 +769,8 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
         # need the storage-safe form that was used when those keys were originally written.
         checkpoint_data = []
         for doc in checkpoint_results.docs:
-            safe_ns = getattr(doc, "checkpoint_ns", "") # storage-safe: for f-strings
-            raw_ns = from_storage_safe_str(safe_ns) # raw: for key builder method
+            safe_ns = getattr(doc, "checkpoint_ns", "")  # storage-safe: for f-strings
+            raw_ns = from_storage_safe_str(safe_ns)  # raw: for key builder method
             checkpoint_id = getattr(doc, "checkpoint_id", "")
             checkpoint_data.append((raw_ns, safe_ns, checkpoint_id))
 
@@ -828,13 +828,13 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
             keep_last: Checkpoints to retain per namespace.  Any value >= 1
                 is a no-op for shallow savers.  Pass ``0`` to delete all.
         """
-        # Validate input 
+        # Validate input
         if not thread_ids:
             raise ValueError(f"``thread_ids`` must be a non-empty sequence")
-        
+
         if keep_last < 0:
             raise ValueError(f"``keep_last`` must be >= 0, got {keep_last}")
-        
+
         if keep_last >= 1:
             return
         for thread_id in thread_ids:

--- a/langgraph/middleware/redis/__init__.py
+++ b/langgraph/middleware/redis/__init__.py
@@ -18,7 +18,11 @@ from langgraph.middleware.redis.composition import (
 from langgraph.middleware.redis.conversation_memory import ConversationMemoryMiddleware
 from langgraph.middleware.redis.semantic_cache import SemanticCacheMiddleware
 from langgraph.middleware.redis.semantic_router import SemanticRouterMiddleware
-from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
+from langgraph.middleware.redis.tool_cache import (
+    DEFAULT_SIDE_EFFECT_PREFIXES,
+    DEFAULT_VOLATILE_ARG_NAMES,
+    ToolResultCacheMiddleware,
+)
 from langgraph.middleware.redis.types import (
     ConversationMemoryConfig,
     MiddlewareConfig,
@@ -53,6 +57,9 @@ __all__ = [
     "from_configs",
     "create_caching_stack",
     "IntegratedRedisMiddleware",
+    # Cache key constants
+    "DEFAULT_VOLATILE_ARG_NAMES",
+    "DEFAULT_SIDE_EFFECT_PREFIXES",
     # Vectorizer utilities
     "AsyncEmbeddingVectorizer",
     "LangChainVectorizer",

--- a/langgraph/middleware/redis/semantic_cache.py
+++ b/langgraph/middleware/redis/semantic_cache.py
@@ -404,7 +404,6 @@ class SemanticCacheMiddleware(AsyncRedisMiddleware):
         try:
             cached = await self._cache.acheck(prompt=prompt)
             if cached:
-                # Cache hit - return cached response
                 cached_response = cached[0].get("response")
                 if cached_response:
                     logger.debug(f"Cache hit for prompt: {prompt[:50]}...")

--- a/langgraph/middleware/redis/tool_cache.py
+++ b/langgraph/middleware/redis/tool_cache.py
@@ -1,13 +1,16 @@
 """Tool result cache middleware.
 
 This module provides a middleware that caches tool call results
-based on semantic similarity using Redis and vector embeddings.
+using exact-match key-value lookup in Redis. Tool caching is
+deterministic: same tool + same args = same result. This uses
+direct Redis GET/SET instead of vector similarity.
+
 Compatible with LangChain's AgentMiddleware protocol for use with create_agent.
 """
 
 import json
 import logging
-from typing import Any, Awaitable, Callable, Union
+from typing import Any, Awaitable, Callable, Dict, Tuple, Union
 
 from langchain.agents.middleware.types import (
     ModelCallResult,
@@ -17,21 +20,43 @@ from langchain.agents.middleware.types import (
 from langchain_core.messages import ToolMessage as LangChainToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
-from redisvl.extensions.cache.llm import SemanticCache
 
 from .aio import AsyncRedisMiddleware
 from .types import ToolCacheConfig
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_VOLATILE_ARG_NAMES: frozenset[str] = frozenset(
+    {
+        "timestamp",
+        "current_time",
+        "now",
+        "date",
+        "today",
+        "current_date",
+        "current_timestamp",
+    }
+)
+
+DEFAULT_SIDE_EFFECT_PREFIXES: Tuple[str, ...] = (
+    "send_",
+    "delete_",
+    "create_",
+    "update_",
+    "remove_",
+    "write_",
+    "post_",
+    "put_",
+    "patch_",
+)
+
 
 class ToolResultCacheMiddleware(AsyncRedisMiddleware):
-    """Middleware that caches tool call results based on semantic similarity.
+    """Middleware that caches tool call results using exact-match lookup.
 
-    Uses redisvl.extensions.cache.llm.SemanticCache to store and retrieve
-    cached tool results. When a tool call is semantically similar to a previous
-    call (within the distance threshold), the cached result is returned
-    without executing the tool.
+    Uses direct Redis GET/SET for deterministic tool result caching.
+    When a tool is called with the same arguments as a previous call,
+    the cached result is returned without executing the tool.
 
     Tool caching is especially useful for expensive operations like:
     - API calls to external services
@@ -64,7 +89,6 @@ class ToolResultCacheMiddleware(AsyncRedisMiddleware):
         ```
     """
 
-    _cache: SemanticCache
     _config: ToolCacheConfig
 
     def __init__(self, config: ToolCacheConfig) -> None:
@@ -77,31 +101,12 @@ class ToolResultCacheMiddleware(AsyncRedisMiddleware):
         self._config = config
 
     async def _setup_async(self) -> None:
-        """Set up the SemanticCache instance for tool results.
+        """Set up the tool cache.
 
-        Note: SemanticCache from redisvl uses synchronous Redis operations
-        internally, so we must provide redis_url and let it manage its own
-        sync connection rather than passing our async client.
+        No additional setup needed — the tool cache uses the async Redis
+        client from the base class directly for GET/SET operations.
         """
-        cache_kwargs: dict[str, Any] = {
-            "name": self._config.name,
-            "distance_threshold": self._config.distance_threshold,
-        }
-
-        # SemanticCache requires a sync Redis connection
-        # Use redis_url to let it create its own connection
-        if self._config.redis_url:
-            cache_kwargs["redis_url"] = self._config.redis_url
-        elif self._config.connection_args:
-            cache_kwargs["connection_kwargs"] = self._config.connection_args
-
-        if self._config.vectorizer is not None:
-            cache_kwargs["vectorizer"] = self._config.vectorizer
-
-        if self._config.ttl_seconds is not None:
-            cache_kwargs["ttl"] = self._config.ttl_seconds
-
-        self._cache = SemanticCache(**cache_kwargs)
+        pass
 
     def _is_tool_cacheable_by_config(self, tool_name: str) -> bool:
         """Check if a tool's results should be cached based on config.
@@ -119,14 +124,94 @@ class ToolResultCacheMiddleware(AsyncRedisMiddleware):
         # Otherwise, cache all tools except excluded ones
         return tool_name not in self._config.excluded_tools
 
+    def _has_volatile_args(self, args: Dict[str, Any]) -> bool:
+        """Check if args contain volatile argument names at any nesting depth.
+
+        Recurses into nested dicts and into dicts inside lists/tuples.
+
+        Args:
+            args: The tool arguments dict.
+
+        Returns:
+            True if any key in args (recursively) matches a configured
+            volatile arg name, False otherwise.
+        """
+        volatile_names = self._config.volatile_arg_names
+        if not volatile_names:
+            return False
+        for key, value in args.items():
+            if key in volatile_names:
+                return True
+            if isinstance(value, dict):
+                if self._has_volatile_args(value):
+                    return True
+            elif isinstance(value, (list, tuple)):
+                for item in value:
+                    if isinstance(item, dict) and self._has_volatile_args(item):
+                        return True
+        return False
+
+    def _has_side_effect_prefix(self, tool_name: str) -> bool:
+        """Check if tool name starts with a configured side-effect prefix.
+
+        Args:
+            tool_name: The name of the tool.
+
+        Returns:
+            True if the tool name matches a side-effect prefix.
+        """
+        prefixes = self._config.side_effect_prefixes
+        if not prefixes:
+            return False
+        return tool_name.startswith(prefixes)
+
+    def _strip_ignored_args(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a copy of args with ignored names removed (top-level only).
+
+        Args:
+            args: The tool arguments dict.
+
+        Returns:
+            A new dict without the ignored keys, or the original if nothing
+            to strip.
+        """
+        if not isinstance(args, dict):
+            return {}
+        ignored = self._config.ignored_arg_names
+        if not ignored:
+            return args
+        return {k: v for k, v in args.items() if k not in ignored}
+
+    @staticmethod
+    def _extract_args(request: ToolCallRequest) -> Dict[str, Any]:
+        """Extract args dict from a request (dict or ToolCallRequest).
+
+        Args:
+            request: The tool call request.
+
+        Returns:
+            The arguments dict.
+        """
+        if isinstance(request, dict):
+            return request.get("args", {})
+        tool_call = getattr(request, "tool_call", None)
+        if isinstance(tool_call, dict):
+            return tool_call.get("args", {})
+        return {}
+
     def _is_tool_cacheable(self, request: ToolCallRequest) -> bool:
         """Check if a tool's results should be cached.
 
-        Checks both tool metadata (LangChain standard) and middleware config.
-        Tool metadata takes precedence over config.
+        Uses a priority chain inspired by SQL function volatility and
+        MCP ToolAnnotations:
 
-        The tool's metadata can specify {"cacheable": True/False} to override
-        the middleware config. This follows LangChain's pattern for tool metadata.
+        1. ``metadata["cacheable"]`` — explicit override (highest priority)
+        2. ``metadata["destructive"]`` — never cache destructive tools
+        3. ``metadata["volatile"]`` — never cache volatile tools
+        4. ``metadata["read_only"] and metadata["idempotent"]`` — cache
+        5. Side-effect prefix match — never cache
+        6. Volatile arg name in call args — never cache
+        7. Config whitelist / blacklist — existing fallback
 
         Args:
             request: The tool call request containing the tool object.
@@ -143,26 +228,49 @@ class ToolResultCacheMiddleware(AsyncRedisMiddleware):
             tool_name = tool_call.get("name", "") if isinstance(tool_call, dict) else ""
             tool = getattr(request, "tool", None)
 
-        # Check tool metadata first (LangChain standard pattern)
+        # --- Priority 1: explicit cacheable flag (highest) ---
+        metadata: Dict[str, Any] = {}
         if tool is not None:
             metadata = getattr(tool, "metadata", None) or {}
             if "cacheable" in metadata:
                 return bool(metadata["cacheable"])
 
-        # Fall back to config-based check
+        # --- Priority 2: destructive metadata → never cache ---
+        if metadata.get("destructive") is True:
+            return False
+
+        # --- Priority 3: volatile metadata → never cache ---
+        if metadata.get("volatile") is True:
+            return False
+
+        # --- Priority 4: read_only + idempotent → cache ---
+        if metadata.get("read_only") is True and metadata.get("idempotent") is True:
+            return True
+
+        # --- Priority 5: side-effect prefix → never cache ---
+        if self._has_side_effect_prefix(tool_name):
+            return False
+
+        # --- Priority 6: volatile arg names → never cache ---
+        args = self._extract_args(request)
+        if self._has_volatile_args(args):
+            return False
+
+        # --- Priority 7: config whitelist / blacklist ---
         return self._is_tool_cacheable_by_config(tool_name)
 
     def _build_cache_key(self, request: ToolCallRequest) -> str:
-        """Build a cache key from the tool request.
+        """Build a deterministic cache key from the tool request.
 
-        Creates a string representation of the tool call that can be
-        used for semantic similarity matching.
+        Creates an exact-match Redis key from the tool name and sorted
+        JSON arguments. This ensures that identical tool calls always
+        produce the same key, and different calls always produce different keys.
 
         Args:
             request: The tool call request (dict or LangChain type).
 
         Returns:
-            A string key for caching.
+            A deterministic string key for Redis GET/SET.
         """
         # Support both dict-style and LangChain ToolCallRequest types
         if isinstance(request, dict):
@@ -177,9 +285,12 @@ class ToolResultCacheMiddleware(AsyncRedisMiddleware):
                 tool_name = ""
                 args = {}
 
-        # Create a human-readable representation for semantic matching
-        args_str = json.dumps(args, sort_keys=True)
-        return f"tool:{tool_name} args:{args_str}"
+        # Strip ignored args before building the key
+        effective_args = self._strip_ignored_args(args)
+
+        # Deterministic key: config name + tool name + sorted JSON args
+        args_str = json.dumps(effective_args, sort_keys=True)
+        return f"{self._config.name}:{tool_name}:{args_str}"
 
     def _serialize_tool_result(self, value: Any) -> str:
         """Serialize a tool result to a JSON string for caching.
@@ -253,10 +364,10 @@ class ToolResultCacheMiddleware(AsyncRedisMiddleware):
             [ToolCallRequest], Awaitable[Union[LangChainToolMessage, Command]]
         ],
     ) -> Union[LangChainToolMessage, Command]:
-        """Wrap a tool call with caching.
+        """Wrap a tool call with exact-match caching.
 
         This method is part of the LangChain AgentMiddleware protocol.
-        Checks the cache for a semantically similar tool call. If found,
+        Checks the cache for an exact tool+args match. If found,
         returns the cached result. Otherwise, calls the handler and
         caches the result.
 
@@ -291,16 +402,17 @@ class ToolResultCacheMiddleware(AsyncRedisMiddleware):
 
         cache_key = self._build_cache_key(request)
 
-        # Try to get from cache using async method
+        # Try to get from cache using exact-match Redis GET
         try:
-            cached = await self._cache.acheck(prompt=cache_key)
-            if cached:
-                # Cache hit - return cached result
-                cached_response = cached[0].get("response")
-                if cached_response:
-                    return self._deserialize_tool_result(
-                        cached_response, tool_name, tool_call_id
-                    )
+            cached_response = await self._redis.get(cache_key)
+            if cached_response is not None:
+                # Decode bytes to string if needed
+                if isinstance(cached_response, bytes):
+                    cached_response = cached_response.decode("utf-8")
+                logger.debug(f"Tool cache hit for key: {cache_key[:80]}")
+                return self._deserialize_tool_result(
+                    cached_response, tool_name, tool_call_id
+                )
         except Exception as e:
             if not self._graceful_degradation:
                 raise
@@ -309,10 +421,16 @@ class ToolResultCacheMiddleware(AsyncRedisMiddleware):
         # Cache miss - call handler
         result = await handler(request)
 
-        # Store in cache using async method
+        # Store in cache using Redis SET with optional TTL
         try:
             result_str = self._serialize_tool_result(result)
-            await self._cache.astore(prompt=cache_key, response=result_str)
+            if self._config.ttl_seconds is not None:
+                await self._redis.set(
+                    cache_key, result_str, ex=self._config.ttl_seconds
+                )
+            else:
+                await self._redis.set(cache_key, result_str)
+            logger.debug(f"Tool cache stored for key: {cache_key[:80]}")
         except Exception as e:
             if not self._graceful_degradation:
                 raise

--- a/langgraph/middleware/redis/types.py
+++ b/langgraph/middleware/redis/types.py
@@ -1,7 +1,17 @@
 """Type definitions and configuration dataclasses for Redis middleware."""
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
+from typing import (
+    AbstractSet,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from redis import Redis
 from redis.asyncio import Redis as AsyncRedis
@@ -66,16 +76,28 @@ class SemanticCacheConfig(MiddlewareConfig):
 class ToolCacheConfig(MiddlewareConfig):
     """Configuration for ToolResultCacheMiddleware.
 
-    Uses SemanticCache with tool_name filtering for tool result caching.
+    Uses exact-match Redis GET/SET for deterministic tool result caching.
+    The cache key is ``{name}:{tool_name}:{sorted_json_args}``.
 
     Attributes:
-        name: Index name for the tool cache.
-        distance_threshold: Maximum distance for cache hits.
+        name: Key prefix for the tool cache.
+        distance_threshold: Deprecated -- ignored. Kept for backward
+            compatibility. Tool cache uses exact-match, not vector similarity.
         ttl_seconds: Time-to-live for cache entries in seconds.
-        vectorizer: Optional vectorizer for embeddings.
+        vectorizer: Deprecated -- ignored. Kept for backward compatibility.
+            Tool cache does not use vector embeddings.
         cacheable_tools: List of tool names to cache. If None, all tools
             except excluded_tools are cached.
         excluded_tools: List of tool names to never cache.
+        volatile_arg_names: Set of argument names whose presence prevents
+            caching (e.g. {"timestamp", "now", "date"}). Checked recursively
+            at any nesting depth. None disables the check.
+        ignored_arg_names: Set of argument names to strip from the cache key
+            before serialization (e.g. {"request_id", "trace_id"}). Stripped
+            at the top level only. None disables stripping.
+        side_effect_prefixes: Tuple of tool-name prefixes that indicate
+            side-effecting tools which should never be cached
+            (e.g. ("send_", "delete_", "create_")). None disables the check.
     """
 
     name: str = "toolcache"
@@ -84,6 +106,9 @@ class ToolCacheConfig(MiddlewareConfig):
     vectorizer: Optional[Any] = None
     cacheable_tools: Optional[List[str]] = None
     excluded_tools: List[str] = field(default_factory=list)
+    volatile_arg_names: Optional[AbstractSet[str]] = None
+    ignored_arg_names: Optional[AbstractSet[str]] = None
+    side_effect_prefixes: Optional[Tuple[str, ...]] = None
 
 
 @dataclass

--- a/tests/integration/test_middleware_cache_false_hits.py
+++ b/tests/integration/test_middleware_cache_false_hits.py
@@ -1,0 +1,1639 @@
+"""Integration tests for middleware cache false-hit prevention.
+
+Verifies that:
+- Tool cache uses exact-match (Redis GET/SET), so different args never collide.
+- Semantic cache uses vector similarity controlled by distance_threshold, so
+  truly similar prompts share cache entries while distinct prompts do not
+  (depending on threshold).
+
+These tests use TestContainers to spin up a real Redis instance.
+"""
+
+import pytest
+from langchain_core.messages import ToolMessage as LangChainToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from testcontainers.redis import RedisContainer
+
+from langgraph.middleware.redis import (
+    SemanticCacheConfig,
+    SemanticCacheMiddleware,
+    ToolCacheConfig,
+    ToolResultCacheMiddleware,
+)
+
+# Check if sentence-transformers is available
+try:
+    import sentence_transformers  # noqa: F401
+
+    HAS_SENTENCE_TRANSFORMERS = True
+except ImportError:
+    HAS_SENTENCE_TRANSFORMERS = False
+
+requires_sentence_transformers = pytest.mark.skipif(
+    not HAS_SENTENCE_TRANSFORMERS,
+    reason="sentence-transformers not installed",
+)
+
+
+def _extract_args(request):
+    """Extract args dict from either a dict or ToolCallRequest."""
+    if isinstance(request, dict):
+        return request.get("args", {})
+    tool_call = getattr(request, "tool_call", {})
+    return tool_call.get("args", {}) if isinstance(tool_call, dict) else {}
+
+
+def _extract_tool_call_id(request, fallback="call_1"):
+    """Extract tool_call_id from either a dict or ToolCallRequest."""
+    if isinstance(request, dict):
+        return request.get("id", fallback)
+    tool_call = getattr(request, "tool_call", {})
+    return tool_call.get("id", fallback) if isinstance(tool_call, dict) else fallback
+
+
+@pytest.fixture(scope="module")
+def redis_url():
+    """Provide a Redis URL using TestContainers."""
+    redis_container = RedisContainer("redis/redis-stack-server:latest")
+    redis_container.start()
+    try:
+        host = redis_container.get_container_host_ip()
+        port = redis_container.get_exposed_port(6379)
+        yield f"redis://{host}:{port}"
+    finally:
+        redis_container.stop()
+
+
+# ---------------------------------------------------------------------------
+# Negative tests: calls that MUST NOT share cache entries
+# ---------------------------------------------------------------------------
+
+
+class TestToolCacheFalseHitPrevention:
+    """Tests that tool cache does NOT return cached results for different args."""
+
+    @pytest.mark.asyncio
+    async def test_different_args_same_tool_not_cached(self, redis_url: str) -> None:
+        """Two calls to same tool with different args must return different results."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_false_hit",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                app_name = _extract_args(request).get("app_name", "unknown")
+                return LangChainToolMessage(
+                    content=f"Details for {app_name}",
+                    name="get_app_details",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            result1 = await middleware.awrap_tool_call(
+                {
+                    "tool_name": "get_app_details",
+                    "args": {"app_name": "SOMEAPP"},
+                    "id": "c1",
+                },
+                handler,
+            )
+            assert call_count[0] == 1
+            assert "SOMEAPP" in result1.content
+
+            result2 = await middleware.awrap_tool_call(
+                {
+                    "tool_name": "get_app_details",
+                    "args": {"app_name": "SOMEAPP2"},
+                    "id": "c2",
+                },
+                handler,
+            )
+            assert call_count[0] == 2, (
+                f"Handler should be called twice — got call_count={call_count[0]}. "
+                "Cache returned a false hit for different arguments."
+            )
+            assert "SOMEAPP2" in result2.content
+
+    @pytest.mark.asyncio
+    async def test_similar_entity_names_not_confused(self, redis_url: str) -> None:
+        """Entities that differ by only a suffix must not collide in cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_entity_names",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            results = []
+
+            async def handler(request):
+                entity = _extract_args(request).get("entity", "unknown")
+                return LangChainToolMessage(
+                    content=f"Data for {entity}",
+                    name="lookup",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            entities = ["ProjectAlpha", "ProjectAlpha2", "ProjectBeta", "ProjectBeta2"]
+            for entity in entities:
+                result = await middleware.awrap_tool_call(
+                    {
+                        "tool_name": "lookup",
+                        "args": {"entity": entity},
+                        "id": f"c_{entity}",
+                    },
+                    handler,
+                )
+                results.append(result.content)
+
+            for i, entity in enumerate(entities):
+                assert entity in results[i], (
+                    f"Expected '{entity}' in result[{i}]='{results[i]}'. "
+                    "Cache returned wrong entity's data."
+                )
+
+    @pytest.mark.asyncio
+    async def test_numeric_arg_difference(self, redis_url: str) -> None:
+        """Args that differ only by a numeric value must not share cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_numeric_diff",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                page = _extract_args(request).get("page", 0)
+                return LangChainToolMessage(
+                    content=f"Page {page} results",
+                    name="search",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            r1 = await middleware.awrap_tool_call(
+                {
+                    "tool_name": "search",
+                    "args": {"query": "redis", "page": 1},
+                    "id": "c1",
+                },
+                handler,
+            )
+            r2 = await middleware.awrap_tool_call(
+                {
+                    "tool_name": "search",
+                    "args": {"query": "redis", "page": 2},
+                    "id": "c2",
+                },
+                handler,
+            )
+
+            assert call_count[0] == 2
+            assert "Page 1" in r1.content
+            assert "Page 2" in r2.content
+
+    @pytest.mark.asyncio
+    async def test_extra_arg_present_vs_absent(self, redis_url: str) -> None:
+        """Calls with an extra arg vs without must not share cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_extra_arg",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                args = _extract_args(request)
+                return LangChainToolMessage(
+                    content=f"args={args}",
+                    name="fetch",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            await middleware.awrap_tool_call(
+                {
+                    "tool_name": "fetch",
+                    "args": {"url": "https://example.com"},
+                    "id": "c1",
+                },
+                handler,
+            )
+            await middleware.awrap_tool_call(
+                {
+                    "tool_name": "fetch",
+                    "args": {"url": "https://example.com", "timeout": 30},
+                    "id": "c2",
+                },
+                handler,
+            )
+            assert call_count[0] == 2, "Extra arg should cause a cache miss"
+
+    @pytest.mark.asyncio
+    async def test_different_tool_names_same_args(self, redis_url: str) -> None:
+        """Different tool names with identical args must not share cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_cross_tool",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                if isinstance(request, dict):
+                    name = request.get("tool_name", "")
+                else:
+                    tc = getattr(request, "tool_call", {})
+                    name = tc.get("name", "") if isinstance(tc, dict) else ""
+                return LangChainToolMessage(
+                    content=f"from {name}",
+                    name=name,
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            r1 = await middleware.awrap_tool_call(
+                {"tool_name": "search_web", "args": {"q": "hello"}, "id": "c1"},
+                handler,
+            )
+            r2 = await middleware.awrap_tool_call(
+                {"tool_name": "search_db", "args": {"q": "hello"}, "id": "c2"},
+                handler,
+            )
+
+            assert call_count[0] == 2
+            assert "search_web" in r1.content
+            assert "search_db" in r2.content
+
+    @pytest.mark.asyncio
+    async def test_nested_object_one_field_differs(self, redis_url: str) -> None:
+        """Nested args differing in one field must not share cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_nested_diff",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                args = _extract_args(request)
+                return LangChainToolMessage(
+                    content=f"result={args}",
+                    name="query",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            args_a = {"filter": {"status": "active", "region": "us-east-1"}}
+            args_b = {"filter": {"status": "active", "region": "us-west-2"}}
+
+            await middleware.awrap_tool_call(
+                {"tool_name": "query", "args": args_a, "id": "c1"}, handler
+            )
+            await middleware.awrap_tool_call(
+                {"tool_name": "query", "args": args_b, "id": "c2"}, handler
+            )
+
+            assert call_count[0] == 2, "Nested arg difference should cause a cache miss"
+
+    @pytest.mark.asyncio
+    async def test_empty_string_vs_missing_key(self, redis_url: str) -> None:
+        """Args with empty string value vs absent key must not share cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_empty_vs_missing",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                args = _extract_args(request)
+                return LangChainToolMessage(
+                    content=f"args={args}",
+                    name="tool",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            await middleware.awrap_tool_call(
+                {"tool_name": "tool", "args": {"name": ""}, "id": "c1"}, handler
+            )
+            await middleware.awrap_tool_call(
+                {"tool_name": "tool", "args": {}, "id": "c2"}, handler
+            )
+
+            assert call_count[0] == 2, "Empty string and missing key are different args"
+
+    @pytest.mark.asyncio
+    async def test_interleaved_calls_return_correct_results(
+        self, redis_url: str
+    ) -> None:
+        """Alternating A/B/A/B calls must return the right result each time."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_interleaved",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                city = _extract_args(request).get("city", "")
+                return LangChainToolMessage(
+                    content=f"Weather in {city}",
+                    name="weather",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            results = []
+            for city in ["Paris", "London", "Paris", "London"]:
+                r = await middleware.awrap_tool_call(
+                    {"tool_name": "weather", "args": {"city": city}, "id": f"c_{city}"},
+                    handler,
+                )
+                results.append(r.content)
+
+            # Handler called twice (Paris miss, London miss, Paris hit, London hit)
+            assert call_count[0] == 2
+            assert "Weather in Paris" in results[0] and "Weather in Paris" in results[2]
+            assert (
+                "Weather in London" in results[1] and "Weather in London" in results[3]
+            )
+
+    @pytest.mark.asyncio
+    async def test_tool_call_request_objects_not_confused(self, redis_url: str) -> None:
+        """ToolCallRequest objects with different args must not share cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_tcr_objects",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                args = _extract_args(request)
+                return LangChainToolMessage(
+                    content=f"result for {args.get('id', '')}",
+                    name="lookup",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            tcr1 = ToolCallRequest(
+                tool_call={"name": "lookup", "args": {"id": "user_101"}, "id": "c1"},
+                tool=None,
+                state={},
+                runtime={},
+            )
+            tcr2 = ToolCallRequest(
+                tool_call={"name": "lookup", "args": {"id": "user_102"}, "id": "c2"},
+                tool=None,
+                state={},
+                runtime={},
+            )
+
+            r1 = await middleware.awrap_tool_call(tcr1, handler)
+            r2 = await middleware.awrap_tool_call(tcr2, handler)
+
+            assert call_count[0] == 2
+            assert "user_101" in r1.content
+            assert "user_102" in r2.content
+
+
+# ---------------------------------------------------------------------------
+# Positive tests: calls that MUST share cache entries
+# ---------------------------------------------------------------------------
+
+
+class TestToolCachePositiveHits:
+    """Tests that identical tool calls DO return cached results."""
+
+    @pytest.mark.asyncio
+    async def test_same_args_same_tool_is_cached(self, redis_url: str) -> None:
+        """Two calls with identical args should use cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_exact_hit",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="App details result",
+                    name="get_app_details",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            req = {
+                "tool_name": "get_app_details",
+                "args": {"app_name": "SOMEAPP"},
+                "id": "c1",
+            }
+            await middleware.awrap_tool_call(req, handler)
+
+            req2 = {
+                "tool_name": "get_app_details",
+                "args": {"app_name": "SOMEAPP"},
+                "id": "c2",
+            }
+            await middleware.awrap_tool_call(req2, handler)
+
+            assert call_count[0] == 1, "Identical args should hit cache"
+
+    @pytest.mark.asyncio
+    async def test_different_key_order_same_values_cached(self, redis_url: str) -> None:
+        """Args with different key insertion order but same values should cache hit.
+
+        _build_cache_key uses json.dumps(args, sort_keys=True), so
+        {"b": 2, "a": 1} and {"a": 1, "b": 2} produce the same key.
+        """
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_key_order",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="result",
+                    name="search",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            await middleware.awrap_tool_call(
+                {"tool_name": "search", "args": {"b": 2, "a": 1}, "id": "c1"}, handler
+            )
+            await middleware.awrap_tool_call(
+                {"tool_name": "search", "args": {"a": 1, "b": 2}, "id": "c2"}, handler
+            )
+
+            assert call_count[0] == 1, "sort_keys=True should normalise key order"
+
+    @pytest.mark.asyncio
+    async def test_cached_result_preserves_tool_message_fields(
+        self, redis_url: str
+    ) -> None:
+        """Cached ToolMessage must have correct name and content."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_fields",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+
+            async def handler(request):
+                return LangChainToolMessage(
+                    content="42",
+                    name="calculate",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            # Store
+            await middleware.awrap_tool_call(
+                {"tool_name": "calculate", "args": {"expr": "6*7"}, "id": "c1"},
+                handler,
+            )
+            # Retrieve from cache
+            cached = await middleware.awrap_tool_call(
+                {"tool_name": "calculate", "args": {"expr": "6*7"}, "id": "c2"},
+                handler,
+            )
+
+            assert isinstance(cached, LangChainToolMessage)
+            assert cached.name == "calculate"
+            assert "42" in cached.content
+
+    @pytest.mark.asyncio
+    async def test_multiple_tools_cached_independently(self, redis_url: str) -> None:
+        """Different tools with same args each get their own cache entry."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_independent",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                if isinstance(request, dict):
+                    name = request.get("tool_name", "")
+                else:
+                    tc = getattr(request, "tool_call", {})
+                    name = tc.get("name", "") if isinstance(tc, dict) else ""
+                return LangChainToolMessage(
+                    content=f"from {name}",
+                    name=name,
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            args = {"q": "test"}
+
+            # Two different tools, same args — 2 handler calls
+            await middleware.awrap_tool_call(
+                {"tool_name": "tool_a", "args": args, "id": "c1"}, handler
+            )
+            await middleware.awrap_tool_call(
+                {"tool_name": "tool_b", "args": args, "id": "c2"}, handler
+            )
+            assert call_count[0] == 2
+
+            # Re-call each — both should now be cached
+            ra = await middleware.awrap_tool_call(
+                {"tool_name": "tool_a", "args": args, "id": "c3"}, handler
+            )
+            rb = await middleware.awrap_tool_call(
+                {"tool_name": "tool_b", "args": args, "id": "c4"}, handler
+            )
+            assert call_count[0] == 2, "Re-calls should hit cache"
+            assert "tool_a" in ra.content
+            assert "tool_b" in rb.content
+
+    @pytest.mark.asyncio
+    async def test_many_identical_calls_handler_once(self, redis_url: str) -> None:
+        """Calling same tool 10 times with identical args invokes handler once."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_many_calls",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="pong",
+                    name="ping",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            for i in range(10):
+                r = await middleware.awrap_tool_call(
+                    {"tool_name": "ping", "args": {"host": "redis.io"}, "id": f"c{i}"},
+                    handler,
+                )
+                assert "pong" in r.content
+
+            assert call_count[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_tool_call_request_object_exact_cache_hit(
+        self, redis_url: str
+    ) -> None:
+        """ToolCallRequest objects with identical args should cache hit."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tcr_exact_hit",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="user data",
+                    name="get_user",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            tcr1 = ToolCallRequest(
+                tool_call={"name": "get_user", "args": {"id": "u42"}, "id": "c1"},
+                tool=None,
+                state={},
+                runtime={},
+            )
+            tcr2 = ToolCallRequest(
+                tool_call={"name": "get_user", "args": {"id": "u42"}, "id": "c2"},
+                tool=None,
+                state={},
+                runtime={},
+            )
+
+            await middleware.awrap_tool_call(tcr1, handler)
+            await middleware.awrap_tool_call(tcr2, handler)
+
+            assert call_count[0] == 1, "Identical ToolCallRequest args should cache hit"
+
+
+# ---------------------------------------------------------------------------
+# Config-based caching behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestToolCacheConfigBehaviour:
+    """Tests for cacheable_tools / excluded_tools config options."""
+
+    @pytest.mark.asyncio
+    async def test_excluded_tool_always_calls_handler(self, redis_url: str) -> None:
+        """Tool in excluded_tools must never be cached."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_excluded",
+            excluded_tools=["random_number"],
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content=f"roll {call_count[0]}",
+                    name="random_number",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            req = {"tool_name": "random_number", "args": {"sides": 6}, "id": "c1"}
+            r1 = await middleware.awrap_tool_call(req, handler)
+            r2 = await middleware.awrap_tool_call(
+                {"tool_name": "random_number", "args": {"sides": 6}, "id": "c2"},
+                handler,
+            )
+
+            assert call_count[0] == 2, "Excluded tool should never cache"
+            assert r1.content != r2.content
+
+    @pytest.mark.asyncio
+    async def test_cacheable_tools_whitelist(self, redis_url: str) -> None:
+        """Only tools in cacheable_tools should be cached."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_tool_whitelist",
+            cacheable_tools=["search"],
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            search_count = [0]
+            calc_count = [0]
+
+            async def handler(request):
+                if isinstance(request, dict):
+                    name = request.get("tool_name", "")
+                else:
+                    tc = getattr(request, "tool_call", {})
+                    name = tc.get("name", "") if isinstance(tc, dict) else ""
+                if name == "search":
+                    search_count[0] += 1
+                else:
+                    calc_count[0] += 1
+                return LangChainToolMessage(
+                    content=f"{name} result",
+                    name=name,
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            args = {"q": "hello"}
+
+            # search: cached after first call
+            await middleware.awrap_tool_call(
+                {"tool_name": "search", "args": args, "id": "c1"}, handler
+            )
+            await middleware.awrap_tool_call(
+                {"tool_name": "search", "args": args, "id": "c2"}, handler
+            )
+            assert search_count[0] == 1, "search should be cached"
+
+            # calculate: not in whitelist, always calls handler
+            await middleware.awrap_tool_call(
+                {"tool_name": "calculate", "args": args, "id": "c3"}, handler
+            )
+            await middleware.awrap_tool_call(
+                {"tool_name": "calculate", "args": args, "id": "c4"}, handler
+            )
+            assert (
+                calc_count[0] == 2
+            ), "calculate not in cacheable_tools, should not cache"
+
+
+# ---------------------------------------------------------------------------
+# Semantic cache (model-level) tests
+# ---------------------------------------------------------------------------
+
+
+@requires_sentence_transformers
+class TestSemanticCacheFalseHitPrevention:
+    """Tests that semantic model cache behaviour is controlled by distance_threshold."""
+
+    @pytest.mark.asyncio
+    async def test_similar_prompts_different_entities_tight_threshold(
+        self, redis_url: str
+    ) -> None:
+        """With a tight threshold, prompts differing by entity should not share cache."""
+        config = SemanticCacheConfig(
+            redis_url=redis_url,
+            name="test_semantic_tight_threshold",
+            distance_threshold=0.05,
+            ttl_seconds=60,
+        )
+
+        async with SemanticCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                messages = (
+                    request.get("messages", [])
+                    if isinstance(request, dict)
+                    else getattr(request, "messages", [])
+                )
+                prompt = messages[-1].get("content", "") if messages else ""
+                return {"content": f"Response to: {prompt}"}
+
+            await middleware.awrap_model_call(
+                {
+                    "messages": [
+                        {"role": "user", "content": "What are app details for SOMEAPP"}
+                    ]
+                },
+                handler,
+            )
+            await middleware.awrap_model_call(
+                {
+                    "messages": [
+                        {"role": "user", "content": "What are app details for SOMEAPP2"}
+                    ]
+                },
+                handler,
+            )
+            assert call_count[0] == 2, (
+                f"Handler should be called twice — got call_count={call_count[0]}. "
+                "Tight threshold should prevent false hit for different entity."
+            )
+
+    @pytest.mark.asyncio
+    async def test_identical_prompts_cached(self, redis_url: str) -> None:
+        """Identical prompts must return cached result."""
+        config = SemanticCacheConfig(
+            redis_url=redis_url,
+            name="test_semantic_exact_hit",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with SemanticCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return {"content": "The answer is 42"}
+
+            msg = {
+                "messages": [
+                    {"role": "user", "content": "What is the meaning of life?"}
+                ]
+            }
+
+            await middleware.awrap_model_call(msg, handler)
+            await middleware.awrap_model_call(msg, handler)
+
+            assert call_count[0] == 1, "Identical prompts should hit cache"
+
+    @pytest.mark.asyncio
+    async def test_numeric_suffix_prompts_tight_threshold(self, redis_url: str) -> None:
+        """With tight threshold, 'order 1001' vs 'order 1002' should not share cache."""
+        config = SemanticCacheConfig(
+            redis_url=redis_url,
+            name="test_semantic_numeric_tight",
+            distance_threshold=0.05,
+            ttl_seconds=60,
+        )
+
+        async with SemanticCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                messages = (
+                    request.get("messages", [])
+                    if isinstance(request, dict)
+                    else getattr(request, "messages", [])
+                )
+                prompt = messages[-1].get("content", "") if messages else ""
+                return {"content": f"Response: {prompt}"}
+
+            await middleware.awrap_model_call(
+                {"messages": [{"role": "user", "content": "Show me order 1001"}]},
+                handler,
+            )
+            await middleware.awrap_model_call(
+                {"messages": [{"role": "user", "content": "Show me order 1002"}]},
+                handler,
+            )
+
+            assert call_count[0] == 2, "Different order numbers must not share cache"
+
+    @pytest.mark.asyncio
+    async def test_truly_different_prompts_miss_cache(self, redis_url: str) -> None:
+        """Completely different prompts must always miss cache."""
+        config = SemanticCacheConfig(
+            redis_url=redis_url,
+            name="test_semantic_different",
+            distance_threshold=0.3,
+            ttl_seconds=60,
+        )
+
+        async with SemanticCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return {"content": f"Response {call_count[0]}"}
+
+            await middleware.awrap_model_call(
+                {
+                    "messages": [
+                        {"role": "user", "content": "What is the weather in Paris?"}
+                    ]
+                },
+                handler,
+            )
+            await middleware.awrap_model_call(
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "How do I bake a chocolate cake?",
+                        }
+                    ]
+                },
+                handler,
+            )
+
+            assert call_count[0] == 2, "Completely different prompts must miss cache"
+
+
+# ---------------------------------------------------------------------------
+# Volatile arg detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestVolatileArgDetection:
+    """Tests that volatile arg names prevent caching."""
+
+    @pytest.mark.asyncio
+    async def test_timestamp_arg_skips_cache(self, redis_url: str) -> None:
+        """Args containing a volatile name like 'timestamp' should skip cache."""
+        from langgraph.middleware.redis.tool_cache import DEFAULT_VOLATILE_ARG_NAMES
+
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_volatile_ts",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            volatile_arg_names=DEFAULT_VOLATILE_ARG_NAMES,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="result",
+                    name="search",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            req = {
+                "tool_name": "search",
+                "args": {"query": "x", "timestamp": 123},
+                "id": "c1",
+            }
+            await middleware.awrap_tool_call(req, handler)
+            await middleware.awrap_tool_call(req, handler)
+
+            assert call_count[0] == 2, "Volatile arg 'timestamp' should prevent caching"
+
+    @pytest.mark.asyncio
+    async def test_nested_date_arg_skips_cache(self, redis_url: str) -> None:
+        """Nested volatile arg name should also prevent caching."""
+        from langgraph.middleware.redis.tool_cache import DEFAULT_VOLATILE_ARG_NAMES
+
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_volatile_nested",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            volatile_arg_names=DEFAULT_VOLATILE_ARG_NAMES,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="result",
+                    name="query",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            req = {
+                "tool_name": "query",
+                "args": {"filter": {"date": "2024-01-01"}},
+                "id": "c1",
+            }
+            await middleware.awrap_tool_call(req, handler)
+            await middleware.awrap_tool_call(req, handler)
+
+            assert call_count[0] == 2, "Nested 'date' arg should prevent caching"
+
+    @pytest.mark.asyncio
+    async def test_no_volatile_args_caches_normally(self, redis_url: str) -> None:
+        """Without volatile args, caching should work normally."""
+        from langgraph.middleware.redis.tool_cache import DEFAULT_VOLATILE_ARG_NAMES
+
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_volatile_normal",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            volatile_arg_names=DEFAULT_VOLATILE_ARG_NAMES,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="result",
+                    name="search",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            req = {"tool_name": "search", "args": {"query": "hello"}, "id": "c1"}
+            await middleware.awrap_tool_call(req, handler)
+            await middleware.awrap_tool_call(
+                {"tool_name": "search", "args": {"query": "hello"}, "id": "c2"},
+                handler,
+            )
+
+            assert call_count[0] == 1, "No volatile args — should cache normally"
+
+    @pytest.mark.asyncio
+    async def test_volatile_detection_disabled_empty_set(self, redis_url: str) -> None:
+        """volatile_arg_names=set() should disable volatile detection."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_volatile_disabled",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            volatile_arg_names=set(),
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="result",
+                    name="search",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            req = {
+                "tool_name": "search",
+                "args": {"query": "x", "timestamp": 123},
+                "id": "c1",
+            }
+            await middleware.awrap_tool_call(req, handler)
+            await middleware.awrap_tool_call(
+                {
+                    "tool_name": "search",
+                    "args": {"query": "x", "timestamp": 123},
+                    "id": "c2",
+                },
+                handler,
+            )
+
+            assert call_count[0] == 1, "Empty set disables volatile detection"
+
+    @pytest.mark.asyncio
+    async def test_custom_volatile_arg_names(self, redis_url: str) -> None:
+        """Custom volatile names like 'as_of' should prevent caching."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_volatile_custom",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            volatile_arg_names={"as_of", "effective_date"},
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="result",
+                    name="report",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            req = {
+                "tool_name": "report",
+                "args": {"metric": "revenue", "as_of": "2024-03-01"},
+                "id": "c1",
+            }
+            await middleware.awrap_tool_call(req, handler)
+            await middleware.awrap_tool_call(req, handler)
+
+            assert call_count[0] == 2, "Custom volatile 'as_of' should prevent caching"
+
+
+# ---------------------------------------------------------------------------
+# Ignored args tests
+# ---------------------------------------------------------------------------
+
+
+class TestIgnoredArgs:
+    """Tests that ignored args are stripped from cache keys."""
+
+    @pytest.mark.asyncio
+    async def test_different_request_id_hits_cache(self, redis_url: str) -> None:
+        """Calls differing only by request_id should share cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_ignored_rid",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            ignored_arg_names={"request_id", "trace_id"},
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="result",
+                    name="search",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            await middleware.awrap_tool_call(
+                {
+                    "tool_name": "search",
+                    "args": {"query": "hello", "request_id": "r1"},
+                    "id": "c1",
+                },
+                handler,
+            )
+            await middleware.awrap_tool_call(
+                {
+                    "tool_name": "search",
+                    "args": {"query": "hello", "request_id": "r2"},
+                    "id": "c2",
+                },
+                handler,
+            )
+
+            assert call_count[0] == 1, "Different request_id should still hit cache"
+
+    @pytest.mark.asyncio
+    async def test_different_trace_id_hits_cache(self, redis_url: str) -> None:
+        """Calls differing only by trace_id should share cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_ignored_tid",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            ignored_arg_names={"request_id", "trace_id"},
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="result",
+                    name="search",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            await middleware.awrap_tool_call(
+                {
+                    "tool_name": "search",
+                    "args": {"query": "hello", "trace_id": "t1"},
+                    "id": "c1",
+                },
+                handler,
+            )
+            await middleware.awrap_tool_call(
+                {
+                    "tool_name": "search",
+                    "args": {"query": "hello", "trace_id": "t2"},
+                    "id": "c2",
+                },
+                handler,
+            )
+
+            assert call_count[0] == 1, "Different trace_id should still hit cache"
+
+    @pytest.mark.asyncio
+    async def test_non_ignored_arg_difference_misses_cache(
+        self, redis_url: str
+    ) -> None:
+        """Calls differing by a non-ignored arg should miss cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_ignored_miss",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            ignored_arg_names={"request_id", "trace_id"},
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="result",
+                    name="search",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            await middleware.awrap_tool_call(
+                {
+                    "tool_name": "search",
+                    "args": {"query": "hello", "user_id": "u1"},
+                    "id": "c1",
+                },
+                handler,
+            )
+            await middleware.awrap_tool_call(
+                {
+                    "tool_name": "search",
+                    "args": {"query": "hello", "user_id": "u2"},
+                    "id": "c2",
+                },
+                handler,
+            )
+
+            assert call_count[0] == 2, "Different user_id is not ignored — cache miss"
+
+
+# ---------------------------------------------------------------------------
+# MCP-style metadata tests
+# ---------------------------------------------------------------------------
+
+
+class TestMCPStyleMetadata:
+    """Tests for MCP-style metadata fields: destructive, volatile, read_only, idempotent."""
+
+    @pytest.mark.asyncio
+    async def test_destructive_metadata_never_cached(self, redis_url: str) -> None:
+        """Tool with metadata={'destructive': True} should never cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_mcp_destructive",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="deleted",
+                    name="wipe_data",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            from unittest.mock import MagicMock
+
+            mock_tool = MagicMock()
+            mock_tool.metadata = {"destructive": True}
+            tcr = ToolCallRequest(
+                tool_call={"name": "wipe_data", "args": {"table": "users"}, "id": "c1"},
+                tool=mock_tool,
+                state={},
+                runtime={},
+            )
+            await middleware.awrap_tool_call(tcr, handler)
+
+            tcr2 = ToolCallRequest(
+                tool_call={"name": "wipe_data", "args": {"table": "users"}, "id": "c2"},
+                tool=mock_tool,
+                state={},
+                runtime={},
+            )
+            await middleware.awrap_tool_call(tcr2, handler)
+
+            assert call_count[0] == 2, "Destructive metadata should prevent caching"
+
+    @pytest.mark.asyncio
+    async def test_volatile_metadata_never_cached(self, redis_url: str) -> None:
+        """Tool with metadata={'volatile': True} should never cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_mcp_volatile",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="time is now",
+                    name="get_time",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            from unittest.mock import MagicMock
+
+            mock_tool = MagicMock()
+            mock_tool.metadata = {"volatile": True}
+            tcr = ToolCallRequest(
+                tool_call={"name": "get_time", "args": {}, "id": "c1"},
+                tool=mock_tool,
+                state={},
+                runtime={},
+            )
+            await middleware.awrap_tool_call(tcr, handler)
+
+            tcr2 = ToolCallRequest(
+                tool_call={"name": "get_time", "args": {}, "id": "c2"},
+                tool=mock_tool,
+                state={},
+                runtime={},
+            )
+            await middleware.awrap_tool_call(tcr2, handler)
+
+            assert call_count[0] == 2, "Volatile metadata should prevent caching"
+
+    @pytest.mark.asyncio
+    async def test_read_only_idempotent_cached(self, redis_url: str) -> None:
+        """Tool with read_only=True + idempotent=True should cache."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_mcp_readonly",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="data",
+                    name="get_user",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            from unittest.mock import MagicMock
+
+            mock_tool = MagicMock()
+            mock_tool.metadata = {"read_only": True, "idempotent": True}
+            tcr = ToolCallRequest(
+                tool_call={
+                    "name": "get_user",
+                    "args": {"id": "u42"},
+                    "id": "c1",
+                },
+                tool=mock_tool,
+                state={},
+                runtime={},
+            )
+            await middleware.awrap_tool_call(tcr, handler)
+
+            tcr2 = ToolCallRequest(
+                tool_call={
+                    "name": "get_user",
+                    "args": {"id": "u42"},
+                    "id": "c2",
+                },
+                tool=mock_tool,
+                state={},
+                runtime={},
+            )
+            await middleware.awrap_tool_call(tcr2, handler)
+
+            assert call_count[0] == 1, "read_only+idempotent should cache"
+
+    @pytest.mark.asyncio
+    async def test_cacheable_true_overrides_destructive(self, redis_url: str) -> None:
+        """Explicit cacheable=True should override destructive=True."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_mcp_override",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="result",
+                    name="special_tool",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            from unittest.mock import MagicMock
+
+            mock_tool = MagicMock()
+            mock_tool.metadata = {"cacheable": True, "destructive": True}
+            tcr = ToolCallRequest(
+                tool_call={
+                    "name": "special_tool",
+                    "args": {"x": 1},
+                    "id": "c1",
+                },
+                tool=mock_tool,
+                state={},
+                runtime={},
+            )
+            await middleware.awrap_tool_call(tcr, handler)
+
+            tcr2 = ToolCallRequest(
+                tool_call={
+                    "name": "special_tool",
+                    "args": {"x": 1},
+                    "id": "c2",
+                },
+                tool=mock_tool,
+                state={},
+                runtime={},
+            )
+            await middleware.awrap_tool_call(tcr2, handler)
+
+            assert call_count[0] == 1, "cacheable=True overrides destructive"
+
+
+# ---------------------------------------------------------------------------
+# Side-effect prefix tests
+# ---------------------------------------------------------------------------
+
+
+class TestSideEffectPrefixes:
+    """Tests for side-effect prefix matching."""
+
+    @pytest.mark.asyncio
+    async def test_send_prefix_never_cached(self, redis_url: str) -> None:
+        """Tool named 'send_email' should skip cache when prefixes enabled."""
+        from langgraph.middleware.redis.tool_cache import DEFAULT_SIDE_EFFECT_PREFIXES
+
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_prefix_send",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            side_effect_prefixes=DEFAULT_SIDE_EFFECT_PREFIXES,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="sent",
+                    name="send_email",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            req = {
+                "tool_name": "send_email",
+                "args": {"to": "user@test.com"},
+                "id": "c1",
+            }
+            await middleware.awrap_tool_call(req, handler)
+            await middleware.awrap_tool_call(
+                {
+                    "tool_name": "send_email",
+                    "args": {"to": "user@test.com"},
+                    "id": "c2",
+                },
+                handler,
+            )
+
+            assert call_count[0] == 2, "send_ prefix should prevent caching"
+
+    @pytest.mark.asyncio
+    async def test_delete_prefix_never_cached(self, redis_url: str) -> None:
+        """Tool named 'delete_record' should skip cache."""
+        from langgraph.middleware.redis.tool_cache import DEFAULT_SIDE_EFFECT_PREFIXES
+
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_prefix_delete",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            side_effect_prefixes=DEFAULT_SIDE_EFFECT_PREFIXES,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="deleted",
+                    name="delete_record",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            req = {
+                "tool_name": "delete_record",
+                "args": {"id": "r1"},
+                "id": "c1",
+            }
+            await middleware.awrap_tool_call(req, handler)
+            await middleware.awrap_tool_call(
+                {"tool_name": "delete_record", "args": {"id": "r1"}, "id": "c2"},
+                handler,
+            )
+
+            assert call_count[0] == 2, "delete_ prefix should prevent caching"
+
+    @pytest.mark.asyncio
+    async def test_get_prefix_cached_normally(self, redis_url: str) -> None:
+        """Tool named 'get_data' should cache normally."""
+        from langgraph.middleware.redis.tool_cache import DEFAULT_SIDE_EFFECT_PREFIXES
+
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_prefix_get",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            side_effect_prefixes=DEFAULT_SIDE_EFFECT_PREFIXES,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="data",
+                    name="get_data",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            req = {"tool_name": "get_data", "args": {"key": "a"}, "id": "c1"}
+            await middleware.awrap_tool_call(req, handler)
+            await middleware.awrap_tool_call(
+                {"tool_name": "get_data", "args": {"key": "a"}, "id": "c2"},
+                handler,
+            )
+
+            assert call_count[0] == 1, "get_ prefix should cache normally"
+
+    @pytest.mark.asyncio
+    async def test_cacheable_metadata_overrides_prefix(self, redis_url: str) -> None:
+        """cacheable=True in metadata should override side-effect prefix."""
+        from langgraph.middleware.redis.tool_cache import DEFAULT_SIDE_EFFECT_PREFIXES
+
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_prefix_override",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            side_effect_prefixes=DEFAULT_SIDE_EFFECT_PREFIXES,
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="ok",
+                    name="delete_user",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            from unittest.mock import MagicMock
+
+            mock_tool = MagicMock()
+            mock_tool.metadata = {"cacheable": True}
+
+            tcr = ToolCallRequest(
+                tool_call={
+                    "name": "delete_user",
+                    "args": {"id": "u1"},
+                    "id": "c1",
+                },
+                tool=mock_tool,
+                state={},
+                runtime={},
+            )
+            await middleware.awrap_tool_call(tcr, handler)
+
+            tcr2 = ToolCallRequest(
+                tool_call={
+                    "name": "delete_user",
+                    "args": {"id": "u1"},
+                    "id": "c2",
+                },
+                tool=mock_tool,
+                state={},
+                runtime={},
+            )
+            await middleware.awrap_tool_call(tcr2, handler)
+
+            assert call_count[0] == 1, "cacheable=True overrides side-effect prefix"
+
+    @pytest.mark.asyncio
+    async def test_side_effect_disabled_empty_tuple(self, redis_url: str) -> None:
+        """side_effect_prefixes=() should disable prefix checking."""
+        config = ToolCacheConfig(
+            redis_url=redis_url,
+            name="test_prefix_disabled",
+            distance_threshold=0.2,
+            ttl_seconds=60,
+            side_effect_prefixes=(),
+        )
+
+        async with ToolResultCacheMiddleware(config) as middleware:
+            call_count = [0]
+
+            async def handler(request):
+                call_count[0] += 1
+                return LangChainToolMessage(
+                    content="sent",
+                    name="send_email",
+                    tool_call_id=_extract_tool_call_id(request),
+                )
+
+            req = {
+                "tool_name": "send_email",
+                "args": {"to": "user@test.com"},
+                "id": "c1",
+            }
+            await middleware.awrap_tool_call(req, handler)
+            await middleware.awrap_tool_call(
+                {
+                    "tool_name": "send_email",
+                    "args": {"to": "user@test.com"},
+                    "id": "c2",
+                },
+                handler,
+            )
+
+            assert call_count[0] == 1, "Empty tuple disables prefix check"

--- a/tests/integration/test_middleware_create_agent.py
+++ b/tests/integration/test_middleware_create_agent.py
@@ -22,6 +22,22 @@ def redis_container():
     container.stop()
 
 
+@pytest.fixture(scope="module")
+def default_vectorizer():
+    """Pre-load and keep the default HuggingFace vectorizer alive for the module.
+
+    redisvl's SemanticCache uses a HuggingFace SentenceTransformer whose
+    initialization relies on a global httpx.Client in huggingface_hub.  When
+    many SentenceTransformer instances are created and garbage-collected across
+    tests (especially in the full test suite), the global client can be closed
+    before a subsequent test tries to use it.  Keeping a single vectorizer
+    reference alive for the module prevents this.
+    """
+    from redisvl.utils.vectorize import HFTextVectorizer
+
+    return HFTextVectorizer()
+
+
 @pytest.fixture
 def redis_url(redis_container):
     """Get Redis URL from container."""
@@ -37,7 +53,9 @@ class TestCreateAgentWithMiddleware:
         not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
     )
     @pytest.mark.asyncio
-    async def test_semantic_cache_with_real_agent(self, redis_url: str):
+    async def test_semantic_cache_with_real_agent(
+        self, redis_url: str, default_vectorizer
+    ):
         """Test SemanticCacheMiddleware with a real LangChain agent."""
         from langchain.agents import create_agent
         from langchain_core.messages import HumanMessage
@@ -64,6 +82,7 @@ class TestCreateAgentWithMiddleware:
                 name=cache_name,
                 ttl_seconds=60,
                 distance_threshold=0.1,
+                vectorizer=default_vectorizer,
             )
         )
 
@@ -219,7 +238,7 @@ class TestCreateAgentWithMiddleware:
             await middleware.aclose()
 
     @pytest.mark.asyncio
-    async def test_cache_miss_handler_return(self, redis_url: str):
+    async def test_cache_miss_handler_return(self, redis_url: str, default_vectorizer):
         """Test what the handler returns on cache miss.
 
         This verifies the handler return type that our middleware must handle.
@@ -241,6 +260,7 @@ class TestCreateAgentWithMiddleware:
                 redis_url=redis_url,
                 name=cache_name,
                 ttl_seconds=60,
+                vectorizer=default_vectorizer,
             )
         )
 
@@ -374,7 +394,9 @@ class TestCreateAgentWithMiddleware:
             await middleware.aclose()
 
     @pytest.mark.asyncio
-    async def test_multiple_middleware_cache_miss(self, redis_url: str):
+    async def test_multiple_middleware_cache_miss(
+        self, redis_url: str, default_vectorizer
+    ):
         """Test multiple middleware together - simulating notebook scenario.
 
         This is the exact pattern used in middleware_composition.ipynb
@@ -400,6 +422,7 @@ class TestCreateAgentWithMiddleware:
                 redis_url=redis_url,
                 name=cache_name,
                 ttl_seconds=60,
+                vectorizer=default_vectorizer,
             )
         )
 
@@ -459,7 +482,9 @@ class TestCreateAgentWithMiddleware:
             await tool_cache.aclose()
 
     @pytest.mark.asyncio
-    async def test_multiple_middleware_with_tool_calls(self, redis_url: str):
+    async def test_multiple_middleware_with_tool_calls(
+        self, redis_url: str, default_vectorizer
+    ):
         """Test middleware with a response that HAS tool_calls.
 
         The routing issue happens when the model wants to call a tool.
@@ -482,6 +507,7 @@ class TestCreateAgentWithMiddleware:
                 name=cache_name,
                 ttl_seconds=60,
                 cache_final_only=True,  # Should NOT cache tool call responses
+                vectorizer=default_vectorizer,
             )
         )
 
@@ -638,7 +664,9 @@ class TestCreateAgentWithMiddleware:
             await middleware.aclose()
 
     @pytest.mark.asyncio
-    async def test_tool_calling_flow_skips_cache_on_tool_results(self, redis_url: str):
+    async def test_tool_calling_flow_skips_cache_on_tool_results(
+        self, redis_url: str, default_vectorizer
+    ):
         """Test that cache is skipped when request contains tool results.
 
         This is the bug that caused KeyError: 'model' in notebooks.
@@ -661,6 +689,7 @@ class TestCreateAgentWithMiddleware:
                 name=cache_name,
                 ttl_seconds=60,
                 cache_final_only=True,
+                vectorizer=default_vectorizer,
             )
         )
 

--- a/tests/test_issue_159_aprune_keep_last.py
+++ b/tests/test_issue_159_aprune_keep_last.py
@@ -17,15 +17,14 @@ import time
 import pytest
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata
+from redisvl.query import FilterQuery
+from redisvl.query.filter import Tag
 from ulid import ULID
 
 from langgraph.checkpoint.redis import RedisSaver
 from langgraph.checkpoint.redis.aio import AsyncRedisSaver
 from langgraph.checkpoint.redis.ashallow import AsyncShallowRedisSaver
 from langgraph.checkpoint.redis.shallow import ShallowRedisSaver
-from redisvl.query import FilterQuery
-from redisvl.query.filter import Tag
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -179,13 +178,18 @@ async def test_aprune_per_namespace_isolation(redis_url: str) -> None:
         await saver.aprune([thread_id], keep_last=1)
 
         # Latest in root namespace must survive
-        assert await saver.aget_tuple(_config(thread_id, root_ids[-1], root_ns)) is not None
+        assert (
+            await saver.aget_tuple(_config(thread_id, root_ids[-1], root_ns))
+            is not None
+        )
         # Older root checkpoints evicted
         for cp_id in root_ids[:-1]:
             assert await saver.aget_tuple(_config(thread_id, cp_id, root_ns)) is None
 
         # Latest in subgraph namespace must also survive
-        assert await saver.aget_tuple(_config(thread_id, sub_ids[-1], sub_ns)) is not None
+        assert (
+            await saver.aget_tuple(_config(thread_id, sub_ids[-1], sub_ns)) is not None
+        )
         # Older subgraph checkpoints evicted
         for cp_id in sub_ids[:-1]:
             assert await saver.aget_tuple(_config(thread_id, cp_id, sub_ns)) is None
@@ -428,17 +432,20 @@ def test_shallow_prune_keep_last_0_deletes_all(redis_url: str) -> None:
         result = saver.get_tuple(_config(thread_id, cp_id))
         assert result is None, "Shallow checkpoint must be deleted with keep_last=0"
 
-  # ---------------------------------------------------------------------------
-  # Validation tests
-  # ---------------------------------------------------------------------------
-  
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
 def test_prune_negative_keep_last_raises(redis_url: str) -> None:
     """prune(keep_last=-1) must raise ValueError immediately."""
     with RedisSaver.from_conn_string(redis_url) as saver:
         saver.setup()
         with pytest.raises(ValueError, match="keep_last"):
             saver.prune(["any-thread"], keep_last=-1)
-            
+
+
 @pytest.mark.asyncio
 async def test_aprune_negative_keep_last_raises(redis_url: str) -> None:
     """aprune(keep_last=-1) must raise ValueError immediately.
@@ -449,12 +456,13 @@ async def test_aprune_negative_keep_last_raises(redis_url: str) -> None:
     async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
         with pytest.raises(ValueError, match="keep_last"):
             await saver.aprune(["any-thread"], keep_last=-1)
-            
-            
-  # ---------------------------------------------------------------------------
-  # Sync coverage
-  # ---------------------------------------------------------------------------
-  
+
+
+# ---------------------------------------------------------------------------
+# Sync coverage
+# ---------------------------------------------------------------------------
+
+
 def test_prune_per_namespace_isolation_sync(redis_url: str) -> None:
     """Sync prune: keep_last applied independently per namespace."""
     with RedisSaver.from_conn_string(redis_url=redis_url) as saver:
@@ -462,7 +470,7 @@ def test_prune_per_namespace_isolation_sync(redis_url: str) -> None:
         thread_id = f"sync-ns-{_make_ulid()}"
         root_ids = [_make_ulid() for _ in range(3)]
         sub_ids = [_make_ulid() for _ in range(3)]
-        
+
         for cp_id in root_ids:
             saver.put(
                 config=_config(thread_id, cp_id, ""),
@@ -477,17 +485,19 @@ def test_prune_per_namespace_isolation_sync(redis_url: str) -> None:
                 metadata=CheckpointMetadata(source="input", step=0, writes={}),
                 new_versions={"messages": "1"},
             )
-            
+
         saver.prune([thread_id], keep_last=1)
-        
+
         assert saver.get_tuple(_config(thread_id, root_ids[-1], "")) is not None
         for cp_id in root_ids[:-1]:
             assert saver.get_tuple(_config(thread_id, cp_id, "")) is None
-            
-        assert saver.get_tuple(_config(thread_id, sub_ids[-1], "subgraph:0")) is not None
+
+        assert (
+            saver.get_tuple(_config(thread_id, sub_ids[-1], "subgraph:0")) is not None
+        )
         for cp_id in sub_ids[:-1]:
             assert saver.get_tuple(_config(thread_id, cp_id, "subgraph:0")) is None
-            
+
 
 def test_prune_removes_associated_writes_sync(redis_url: str) -> None:
     """Sync prune: writes for evicted checkpoints deleted; retained writes survive."""
@@ -495,7 +505,7 @@ def test_prune_removes_associated_writes_sync(redis_url: str) -> None:
         saver.setup()
         thread_id = f"sync-writes-{_make_ulid()}"
         cp_ids = [_make_ulid() for _ in range(2)]
-        
+
         for i, cp_id in enumerate(cp_ids):
             cfg = _config(thread_id, cp_id)
             saver.put(
@@ -509,65 +519,62 @@ def test_prune_removes_associated_writes_sync(redis_url: str) -> None:
                 writes=[("messages", f"write-{i}")],
                 task_id=f"task-{i}",
             )
-        
+
         saver.prune([thread_id], keep_last=1)
-        
+
         assert saver.get_tuple(_config(thread_id, cp_ids[-1])) is not None
         assert saver.get_tuple(_config(thread_id, cp_ids[0])) is None
-        
+
         evicted = saver.checkpoint_writes_index.search(
-            FilterQuery(
-                Tag("checkpoint_id") == cp_ids[0]
-            )
+            FilterQuery(Tag("checkpoint_id") == cp_ids[0])
         )
         assert len(evicted.docs) == 0, "Evicted writes must be removed"
-        
+
         retained = saver.checkpoint_writes_index.search(
-            FilterQuery(
-                Tag("checkpoint_id") == cp_ids[-1]
-            )
+            FilterQuery(Tag("checkpoint_id") == cp_ids[-1])
         )
         assert len(retained.docs) > 0, "Retained writes must survive"
-        
-        
+
+
 def test_prune_empty_thread_is_noop_sync(redis_url: str) -> None:
     """Sync prune on a thread with no checkpoints completes without error."""
     with RedisSaver.from_conn_string(redis_url) as saver:
         saver.setup()
         saver.prune([f"nonexistent-{_make_ulid()}"])
-        
+
+
 def test_prune_does_not_affect_other_threads_sync(redis_url: str) -> None:
     """Sync prune: pruning one thread leaves another thread's checkpoints intact."""
     with RedisSaver.from_conn_string(redis_url) as saver:
-          saver.setup()
-          target = f"sync-target-{_make_ulid()}"
-          other = f"sync-other-{_make_ulid()}"
+        saver.setup()
+        target = f"sync-target-{_make_ulid()}"
+        other = f"sync-other-{_make_ulid()}"
 
-          for thread_id in (target, other):
-              for _ in range(3):
-                  cp_id = _make_ulid()
-                  saver.put(
-                      config=_config(thread_id, cp_id),
-                      checkpoint=_make_checkpoint(cp_id),
-                      metadata=CheckpointMetadata(source="input", step=0, writes={}),
-                      new_versions={"messages": "1"},
-                  )
+        for thread_id in (target, other):
+            for _ in range(3):
+                cp_id = _make_ulid()
+                saver.put(
+                    config=_config(thread_id, cp_id),
+                    checkpoint=_make_checkpoint(cp_id),
+                    metadata=CheckpointMetadata(source="input", step=0, writes={}),
+                    new_versions={"messages": "1"},
+                )
 
-          saver.prune([target], keep_last=1)
+        saver.prune([target], keep_last=1)
 
-          other_checkpoints = list(
-              saver.list({"configurable": {"thread_id": other, "checkpoint_ns": ""}})
-          )
-          assert len(other_checkpoints) == 3, "Other thread must be untouched"
-          
-          
+        other_checkpoints = list(
+            saver.list({"configurable": {"thread_id": other, "checkpoint_ns": ""}})
+        )
+        assert len(other_checkpoints) == 3, "Other thread must be untouched"
+
+
 def test_prune_multiple_thread_ids_sync(redis_url: str) -> None:
     """Sync prune: pruning multiple thread_ids in one call works correctly."""
     with RedisSaver.from_conn_string(redis_url) as saver:
         saver.setup()
         threads = [f"multi-{_make_ulid()}" for _ in range(2)]
         all_cp_ids = {}
-        
+
         for thread_id in threads:
             cp_ids = [_make_ulid() for _ in range(3)]
             all_cp_ids[thread_id] = cp_ids
@@ -578,21 +585,22 @@ def test_prune_multiple_thread_ids_sync(redis_url: str) -> None:
                     metadata=CheckpointMetadata(source="input", step=0, writes={}),
                     new_versions={"messages": "1"},
                 )
-                
+
         saver.prune(threads, keep_last=1)
-        
+
         for thread_id, cp_ids in all_cp_ids.items():
             assert saver.get_tuple(_config(thread_id, cp_ids[-1])) is not None
             for old_id in cp_ids[:-1]:
                 assert saver.get_tuple(_config(thread_id, old_id)) is None
-                
+
+
 def test_prune_keep_last_greater_than_total_is_noop_sync(redis_url: str) -> None:
     """Sync prune: keep_last > total checkpoints should not delete anything."""
     with RedisSaver.from_conn_string(redis_url) as saver:
         saver.setup()
         thread_id = f"sync-noop-{_make_ulid()}"
         cp_ids = [_make_ulid() for _ in range(2)]
-        
+
         for cp_id in cp_ids:
             saver.put(
                 config=_config(thread_id, cp_id),
@@ -601,19 +609,20 @@ def test_prune_keep_last_greater_than_total_is_noop_sync(redis_url: str) -> None
                 new_versions={"messages": "1"},
             )
 
-        saver.prune([thread_id], keep_last=100) # way more then 2 stored
-        
+        saver.prune([thread_id], keep_last=100)  # way more then 2 stored
+
         for cp_id in cp_ids:
-            assert saver.get_tuple(_config(thread_id, cp_id)) is not None, (
-                f"All checkpoints must survive when keep_last > total: {cp_id}"
-            )
-            
+            assert (
+                saver.get_tuple(_config(thread_id, cp_id)) is not None
+            ), f"All checkpoints must survive when keep_last > total: {cp_id}"
+
+
 def test_prune_then_continue_sync(redis_url: str) -> None:
     """Sync: after pruning, putting new checkpoints continues working correctly."""
     with RedisSaver.from_conn_string(redis_url) as saver:
         saver.setup()
         thread_id = f"sync-continue-{_make_ulid()}"
-        
+
         # Write some checkpoints, then prune them all
         for _ in range(10):
             cp_id = _make_ulid()
@@ -623,9 +632,9 @@ def test_prune_then_continue_sync(redis_url: str) -> None:
                 metadata=CheckpointMetadata(source="input", step=0, writes={}),
                 new_versions={"messages": "1"},
             )
-        
+
         saver.prune([thread_id], keep_last=0)
-        
+
         # Now write a fresh checkpoint — saver must still work
         new_cp_id = _make_ulid()
         saver.put(
@@ -637,9 +646,8 @@ def test_prune_then_continue_sync(redis_url: str) -> None:
 
         result = saver.get_tuple(_config(thread_id, new_cp_id))
         assert result is not None, "New checkpoint after prune must be retrievable"
-        
-        
-        
+
+
 # ---------------------------------------------------------------------------
 # Key registry (write_keys_zset) cleanup
 # ---------------------------------------------------------------------------
@@ -673,27 +681,36 @@ def test_prune_cleans_write_keys_zset_for_evicted_checkpoints(redis_url: str) ->
             )
 
         # Both zsets must exist before pruning
-        assert saver._key_registry is not None, "Key registry must be initialised by setup()"
-        evicted_zset = saver._key_registry.make_write_keys_zset_key(thread_id, "", cp_ids[0])
-        retained_zset = saver._key_registry.make_write_keys_zset_key(thread_id, "", cp_ids[-1])
+        assert (
+            saver._key_registry is not None
+        ), "Key registry must be initialised by setup()"
+        evicted_zset = saver._key_registry.make_write_keys_zset_key(
+            thread_id, "", cp_ids[0]
+        )
+        retained_zset = saver._key_registry.make_write_keys_zset_key(
+            thread_id, "", cp_ids[-1]
+        )
         assert saver._redis.exists(evicted_zset), "Evicted zset must exist before prune"
-        assert saver._redis.exists(retained_zset), "Retained zset must exist before prune"
+        assert saver._redis.exists(
+            retained_zset
+        ), "Retained zset must exist before prune"
 
         saver.prune([thread_id], keep_last=1)
 
         # Evicted checkpoint's zset must be gone
-        assert not saver._redis.exists(evicted_zset), (
-            "write_keys_zset for evicted checkpoint must be deleted"
-        )
+        assert not saver._redis.exists(
+            evicted_zset
+        ), "write_keys_zset for evicted checkpoint must be deleted"
         # Retained checkpoint's zset must still be there
-        assert saver._redis.exists(retained_zset), (
-            "write_keys_zset for retained checkpoint must survive"
-        )
+        assert saver._redis.exists(
+            retained_zset
+        ), "write_keys_zset for retained checkpoint must survive"
 
 
 # ---------------------------------------------------------------------------
 # checkpoint_latest pointer cleanup
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_prune_keep_last_0_cleans_checkpoint_latest(redis_url: str) -> None:
@@ -704,8 +721,11 @@ async def test_prune_keep_last_0_cleans_checkpoint_latest(redis_url: str) -> Non
     """
     async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
         thread_id = f"latest-ptr-{_make_ulid()}"
-        from langgraph.checkpoint.redis.util import to_storage_safe_id, to_storage_safe_str
-        
+        from langgraph.checkpoint.redis.util import (
+            to_storage_safe_id,
+            to_storage_safe_str,
+        )
+
         cp_id = _make_ulid()
         await saver.aput(
             config=_config(thread_id, cp_id),
@@ -713,17 +733,17 @@ async def test_prune_keep_last_0_cleans_checkpoint_latest(redis_url: str) -> Non
             metadata=CheckpointMetadata(source="input", step=0, writes={}),
             new_versions={"messages": "1"},
         )
-        
+
         safe_tid = to_storage_safe_id(thread_id)
-        safe_ns = to_storage_safe_str("") # root namespace -> "__empty__"
+        safe_ns = to_storage_safe_str("")  # root namespace -> "__empty__"
         pointer_key = f"checkpoint_latest:{safe_tid}:{safe_ns}"
-        
-        # Pointer must exist before pruning 
+
+        # Pointer must exist before pruning
         assert await saver._redis.exists(pointer_key)
-        
+
         await saver.aprune([thread_id], keep_last=0)
-        
-        # Pointer must be gone after full eviction 
-        assert not await saver._redis.exists(pointer_key), ("checkpoint_latest pointer must be cleaned up when keep_last=0")
-        
-        
+
+        # Pointer must be gone after full eviction
+        assert not await saver._redis.exists(
+            pointer_key
+        ), "checkpoint_latest pointer must be cleaned up when keep_last=0"

--- a/tests/test_middleware_composition.py
+++ b/tests/test_middleware_composition.py
@@ -208,10 +208,7 @@ class TestFromConfigs:
 
         mock_client = AsyncMock()
 
-        with (
-            patch("langgraph.middleware.redis.semantic_cache.SemanticCache"),
-            patch("langgraph.middleware.redis.tool_cache.SemanticCache"),
-        ):
+        with patch("langgraph.middleware.redis.semantic_cache.SemanticCache"):
             stack = from_configs(
                 redis_client=mock_client,
                 configs=[
@@ -251,10 +248,7 @@ class TestCreateCachingStack:
 
         mock_client = AsyncMock()
 
-        with (
-            patch("langgraph.middleware.redis.semantic_cache.SemanticCache"),
-            patch("langgraph.middleware.redis.tool_cache.SemanticCache"),
-        ):
+        with patch("langgraph.middleware.redis.semantic_cache.SemanticCache"):
             stack = create_caching_stack(
                 redis_client=mock_client,
                 semantic_cache_ttl=3600,
@@ -271,10 +265,7 @@ class TestCreateCachingStack:
 
         mock_client = AsyncMock()
 
-        with (
-            patch("langgraph.middleware.redis.semantic_cache.SemanticCache"),
-            patch("langgraph.middleware.redis.tool_cache.SemanticCache"),
-        ):
+        with patch("langgraph.middleware.redis.semantic_cache.SemanticCache"):
             stack = create_caching_stack(
                 redis_client=mock_client,
                 cacheable_tools=["search", "calculate"],

--- a/tests/test_middleware_semantic_cache.py
+++ b/tests/test_middleware_semantic_cache.py
@@ -124,7 +124,11 @@ class TestSemanticCacheMiddleware:
             # Cached response is stored as JSON, so we simulate that format
             mock_cache.acheck = AsyncMock(
                 return_value=[
-                    {"response": '{"content": "Cached answer"}', "metadata": {}}
+                    {
+                        "prompt": "What is Python?",
+                        "response": '{"content": "Cached answer"}',
+                        "metadata": {},
+                    }
                 ]
             )
             mock_cache_class.return_value = mock_cache
@@ -391,3 +395,57 @@ class TestSemanticCacheMiddleware:
             # Verify SemanticCache was created with distance_threshold
             call_kwargs = mock_cache_class.call_args.kwargs
             assert call_kwargs.get("distance_threshold") == 0.2
+
+    @pytest.mark.asyncio
+    async def test_similar_prompt_returns_cached_response(self) -> None:
+        """Test that semantically similar (but not identical) prompts return cache hits.
+
+        The semantic cache relies on distance_threshold to control matching.
+        There is no exact-match guard — if the vector search returns a hit
+        within the threshold, the cached response is returned.
+        """
+        from langgraph.middleware.redis.semantic_cache import SemanticCacheMiddleware
+
+        mock_client = AsyncMock()
+        config = SemanticCacheConfig(redis_client=mock_client)
+
+        with patch(
+            "langgraph.middleware.redis.semantic_cache.SemanticCache"
+        ) as mock_cache_class:
+            mock_cache = MagicMock()
+            # Simulate a semantic hit: the stored prompt differs from the query
+            # but is within distance_threshold
+            mock_cache.acheck = AsyncMock(
+                return_value=[
+                    {
+                        "prompt": "What is the Python programming language?",
+                        "response": '{"content": "Python is a language."}',
+                        "metadata": {},
+                    }
+                ]
+            )
+            mock_cache_class.return_value = mock_cache
+
+            middleware = SemanticCacheMiddleware(config)
+            await middleware._ensure_initialized_async()
+
+            handler_called = []
+
+            async def mock_handler(request: dict) -> dict:
+                handler_called.append(True)
+                return {"content": "New answer"}
+
+            # Query with a different but semantically similar prompt
+            request = {
+                "messages": [{"role": "user", "content": "Tell me about Python"}]
+            }
+            result = await middleware.awrap_model_call(request, mock_handler)
+
+            from langchain.agents.middleware.types import ModelResponse
+
+            assert isinstance(result, ModelResponse)
+            assert result.result[0].content == "Python is a language."
+            assert len(handler_called) == 0, (
+                "Handler should NOT be called — semantic similarity "
+                "within threshold should return cached response"
+            )

--- a/tests/test_middleware_tool_cache.py
+++ b/tests/test_middleware_tool_cache.py
@@ -192,6 +192,8 @@ class TestToolResultCacheMiddleware:
         cache_key = middleware._build_cache_key(request)
         assert "search" in cache_key
         assert "Python programming" in cache_key
+        # Verify deterministic key format
+        assert cache_key == 'toolcache:search:{"query": "Python programming"}'
 
     @pytest.mark.asyncio
     async def test_build_cache_key_from_tool_call_request(self) -> None:
@@ -208,6 +210,7 @@ class TestToolResultCacheMiddleware:
         cache_key = middleware._build_cache_key(request)
         assert "search" in cache_key
         assert "Python programming" in cache_key
+        assert cache_key == 'toolcache:search:{"query": "Python programming"}'
 
     @pytest.mark.asyncio
     async def test_build_cache_key_with_complex_args(self) -> None:
@@ -231,40 +234,33 @@ class TestToolResultCacheMiddleware:
         from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
 
         mock_client = AsyncMock()
+        # Simulate Redis GET returning cached data
+        mock_client.get = AsyncMock(return_value=b'{"result": "cached"}')
         config = ToolCacheConfig(redis_client=mock_client)
 
-        with patch(
-            "langgraph.middleware.redis.tool_cache.SemanticCache"
-        ) as mock_cache_class:
-            mock_cache = MagicMock()
-            mock_cache.acheck = AsyncMock(
-                return_value=[{"response": '{"result": "cached"}', "metadata": {}}]
+        middleware = ToolResultCacheMiddleware(config)
+        await middleware._ensure_initialized_async()
+
+        handler_called = []
+
+        async def mock_handler(
+            request: ToolCallRequest,
+        ) -> LangChainToolMessage:
+            handler_called.append(True)
+            return LangChainToolMessage(
+                content="new", name="search", tool_call_id="call_123"
             )
-            mock_cache_class.return_value = mock_cache
 
-            middleware = ToolResultCacheMiddleware(config)
-            await middleware._ensure_initialized_async()
+        request = _make_tool_call_request(
+            "search", args={"query": "test"}, tool_call_id="call_456"
+        )
+        result = await middleware.awrap_tool_call(request, mock_handler)
 
-            handler_called = []
-
-            async def mock_handler(
-                request: ToolCallRequest,
-            ) -> LangChainToolMessage:
-                handler_called.append(True)
-                return LangChainToolMessage(
-                    content="new", name="search", tool_call_id="call_123"
-                )
-
-            request = _make_tool_call_request(
-                "search", args={"query": "test"}, tool_call_id="call_456"
-            )
-            result = await middleware.awrap_tool_call(request, mock_handler)
-
-            # Should return a ToolMessage, not a raw dict
-            assert isinstance(result, LangChainToolMessage)
-            assert result.name == "search"
-            assert result.tool_call_id == "call_456"
-            assert len(handler_called) == 0
+        # Should return a ToolMessage, not a raw dict
+        assert isinstance(result, LangChainToolMessage)
+        assert result.name == "search"
+        assert result.tool_call_id == "call_456"
+        assert len(handler_called) == 0
 
     @pytest.mark.asyncio
     async def test_cache_hit_with_dict_request(self) -> None:
@@ -272,32 +268,24 @@ class TestToolResultCacheMiddleware:
         from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
 
         mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=b'{"result": "cached"}')
         config = ToolCacheConfig(redis_client=mock_client)
 
-        with patch(
-            "langgraph.middleware.redis.tool_cache.SemanticCache"
-        ) as mock_cache_class:
-            mock_cache = MagicMock()
-            mock_cache.acheck = AsyncMock(
-                return_value=[{"response": '{"result": "cached"}', "metadata": {}}]
-            )
-            mock_cache_class.return_value = mock_cache
+        middleware = ToolResultCacheMiddleware(config)
+        await middleware._ensure_initialized_async()
 
-            middleware = ToolResultCacheMiddleware(config)
-            await middleware._ensure_initialized_async()
+        handler_called = []
 
-            handler_called = []
+        async def mock_handler(request: dict) -> dict:
+            handler_called.append(True)
+            return {"result": "new"}
 
-            async def mock_handler(request: dict) -> dict:
-                handler_called.append(True)
-                return {"result": "new"}
+        request = {"tool_name": "search", "args": {"query": "test"}, "id": "c1"}
+        result = await middleware.awrap_tool_call(request, mock_handler)
 
-            request = {"tool_name": "search", "args": {"query": "test"}, "id": "c1"}
-            result = await middleware.awrap_tool_call(request, mock_handler)
-
-            assert isinstance(result, LangChainToolMessage)
-            assert result.name == "search"
-            assert len(handler_called) == 0
+        assert isinstance(result, LangChainToolMessage)
+        assert result.name == "search"
+        assert len(handler_called) == 0
 
     @pytest.mark.asyncio
     async def test_cache_miss_calls_handler(self) -> None:
@@ -305,33 +293,27 @@ class TestToolResultCacheMiddleware:
         from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
 
         mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=None)  # Cache miss
+        mock_client.set = AsyncMock()
         config = ToolCacheConfig(redis_client=mock_client)
 
-        with patch(
-            "langgraph.middleware.redis.tool_cache.SemanticCache"
-        ) as mock_cache_class:
-            mock_cache = MagicMock()
-            mock_cache.acheck = AsyncMock(return_value=[])  # Cache miss
-            mock_cache.astore = AsyncMock()
-            mock_cache_class.return_value = mock_cache
+        middleware = ToolResultCacheMiddleware(config)
+        await middleware._ensure_initialized_async()
 
-            middleware = ToolResultCacheMiddleware(config)
-            await middleware._ensure_initialized_async()
+        expected = LangChainToolMessage(
+            content="new result", name="search", tool_call_id="call_123"
+        )
 
-            expected = LangChainToolMessage(
-                content="new result", name="search", tool_call_id="call_123"
-            )
+        async def mock_handler(
+            request: ToolCallRequest,
+        ) -> LangChainToolMessage:
+            return expected
 
-            async def mock_handler(
-                request: ToolCallRequest,
-            ) -> LangChainToolMessage:
-                return expected
+        request = _make_tool_call_request("search", args={"query": "test"})
+        result = await middleware.awrap_tool_call(request, mock_handler)
 
-            request = _make_tool_call_request("search", args={"query": "test"})
-            result = await middleware.awrap_tool_call(request, mock_handler)
-
-            assert result is expected
-            mock_cache.astore.assert_called_once()
+        assert result is expected
+        mock_client.set.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_non_cacheable_tool_skips_cache(self) -> None:
@@ -339,37 +321,31 @@ class TestToolResultCacheMiddleware:
         from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
 
         mock_client = AsyncMock()
+        mock_client.get = AsyncMock()
+        mock_client.set = AsyncMock()
         config = ToolCacheConfig(
             redis_client=mock_client,
             excluded_tools=["random_tool"],
         )
 
-        with patch(
-            "langgraph.middleware.redis.tool_cache.SemanticCache"
-        ) as mock_cache_class:
-            mock_cache = MagicMock()
-            mock_cache.acheck = AsyncMock()
-            mock_cache.astore = AsyncMock()
-            mock_cache_class.return_value = mock_cache
+        middleware = ToolResultCacheMiddleware(config)
+        await middleware._ensure_initialized_async()
 
-            middleware = ToolResultCacheMiddleware(config)
-            await middleware._ensure_initialized_async()
+        expected = LangChainToolMessage(
+            content="random", name="random_tool", tool_call_id="call_123"
+        )
 
-            expected = LangChainToolMessage(
-                content="random", name="random_tool", tool_call_id="call_123"
-            )
+        async def mock_handler(
+            request: ToolCallRequest,
+        ) -> LangChainToolMessage:
+            return expected
 
-            async def mock_handler(
-                request: ToolCallRequest,
-            ) -> LangChainToolMessage:
-                return expected
+        request = _make_tool_call_request("random_tool")
+        result = await middleware.awrap_tool_call(request, mock_handler)
 
-            request = _make_tool_call_request("random_tool")
-            result = await middleware.awrap_tool_call(request, mock_handler)
-
-            assert result is expected
-            mock_cache.acheck.assert_not_called()
-            mock_cache.astore.assert_not_called()
+        assert result is expected
+        mock_client.get.assert_not_called()
+        mock_client.set.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_graceful_degradation_on_cache_error(self) -> None:
@@ -377,31 +353,25 @@ class TestToolResultCacheMiddleware:
         from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
 
         mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=Exception("Redis error"))
         config = ToolCacheConfig(redis_client=mock_client, graceful_degradation=True)
 
-        with patch(
-            "langgraph.middleware.redis.tool_cache.SemanticCache"
-        ) as mock_cache_class:
-            mock_cache = MagicMock()
-            mock_cache.acheck = AsyncMock(side_effect=Exception("Redis error"))
-            mock_cache_class.return_value = mock_cache
+        middleware = ToolResultCacheMiddleware(config)
+        await middleware._ensure_initialized_async()
 
-            middleware = ToolResultCacheMiddleware(config)
-            await middleware._ensure_initialized_async()
+        expected = LangChainToolMessage(
+            content="handler response", name="search", tool_call_id="call_123"
+        )
 
-            expected = LangChainToolMessage(
-                content="handler response", name="search", tool_call_id="call_123"
-            )
+        async def mock_handler(
+            request: ToolCallRequest,
+        ) -> LangChainToolMessage:
+            return expected
 
-            async def mock_handler(
-                request: ToolCallRequest,
-            ) -> LangChainToolMessage:
-                return expected
+        request = _make_tool_call_request("search", args={"query": "test"})
+        result = await middleware.awrap_tool_call(request, mock_handler)
 
-            request = _make_tool_call_request("search", args={"query": "test"})
-            result = await middleware.awrap_tool_call(request, mock_handler)
-
-            assert result is expected
+        assert result is expected
 
     @pytest.mark.asyncio
     async def test_raises_on_cache_error_without_graceful_degradation(self) -> None:
@@ -409,48 +379,50 @@ class TestToolResultCacheMiddleware:
         from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
 
         mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=Exception("Redis error"))
         config = ToolCacheConfig(redis_client=mock_client, graceful_degradation=False)
 
-        with patch(
-            "langgraph.middleware.redis.tool_cache.SemanticCache"
-        ) as mock_cache_class:
-            mock_cache = MagicMock()
-            mock_cache.acheck = AsyncMock(side_effect=Exception("Redis error"))
-            mock_cache_class.return_value = mock_cache
+        middleware = ToolResultCacheMiddleware(config)
+        await middleware._ensure_initialized_async()
 
-            middleware = ToolResultCacheMiddleware(config)
-            await middleware._ensure_initialized_async()
+        async def mock_handler(
+            request: ToolCallRequest,
+        ) -> LangChainToolMessage:
+            return LangChainToolMessage(
+                content="response", name="search", tool_call_id="call_123"
+            )
 
-            async def mock_handler(
-                request: ToolCallRequest,
-            ) -> LangChainToolMessage:
-                return LangChainToolMessage(
-                    content="response", name="search", tool_call_id="call_123"
-                )
-
-            request = _make_tool_call_request("search", args={"query": "test"})
-            with pytest.raises(Exception, match="Redis error"):
-                await middleware.awrap_tool_call(request, mock_handler)
+        request = _make_tool_call_request("search", args={"query": "test"})
+        with pytest.raises(Exception, match="Redis error"):
+            await middleware.awrap_tool_call(request, mock_handler)
 
     @pytest.mark.asyncio
     async def test_ttl_configuration(self) -> None:
-        """Test that TTL is passed to cache."""
+        """Test that TTL is passed to Redis SET."""
         from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
 
         mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=None)  # Cache miss
+        mock_client.set = AsyncMock()
         config = ToolCacheConfig(redis_client=mock_client, ttl_seconds=7200)
 
-        with patch(
-            "langgraph.middleware.redis.tool_cache.SemanticCache"
-        ) as mock_cache_class:
-            mock_cache = MagicMock()
-            mock_cache_class.return_value = mock_cache
+        middleware = ToolResultCacheMiddleware(config)
+        await middleware._ensure_initialized_async()
 
-            middleware = ToolResultCacheMiddleware(config)
-            await middleware._ensure_initialized_async()
+        async def mock_handler(
+            request: ToolCallRequest,
+        ) -> LangChainToolMessage:
+            return LangChainToolMessage(
+                content="data", name="search", tool_call_id="call_123"
+            )
 
-            call_kwargs = mock_cache_class.call_args.kwargs
-            assert call_kwargs.get("ttl") == 7200
+        request = _make_tool_call_request("search", args={"q": "test"})
+        await middleware.awrap_tool_call(request, mock_handler)
+
+        # Verify SET was called with ex=7200
+        mock_client.set.assert_called_once()
+        call_kwargs = mock_client.set.call_args
+        assert call_kwargs.kwargs.get("ex") == 7200
 
     @pytest.mark.asyncio
     async def test_stores_with_tool_name_metadata(self) -> None:
@@ -458,31 +430,25 @@ class TestToolResultCacheMiddleware:
         from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
 
         mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=None)
+        mock_client.set = AsyncMock()
         config = ToolCacheConfig(redis_client=mock_client)
 
-        with patch(
-            "langgraph.middleware.redis.tool_cache.SemanticCache"
-        ) as mock_cache_class:
-            mock_cache = MagicMock()
-            mock_cache.acheck = AsyncMock(return_value=[])
-            mock_cache.astore = AsyncMock()
-            mock_cache_class.return_value = mock_cache
+        middleware = ToolResultCacheMiddleware(config)
+        await middleware._ensure_initialized_async()
 
-            middleware = ToolResultCacheMiddleware(config)
-            await middleware._ensure_initialized_async()
+        async def mock_handler(
+            request: ToolCallRequest,
+        ) -> LangChainToolMessage:
+            return LangChainToolMessage(
+                content="data", name="api_search", tool_call_id="call_123"
+            )
 
-            async def mock_handler(
-                request: ToolCallRequest,
-            ) -> LangChainToolMessage:
-                return LangChainToolMessage(
-                    content="data", name="api_search", tool_call_id="call_123"
-                )
+        request = _make_tool_call_request("api_search", args={"q": "test"})
+        await middleware.awrap_tool_call(request, mock_handler)
 
-            request = _make_tool_call_request("api_search", args={"q": "test"})
-            await middleware.awrap_tool_call(request, mock_handler)
-
-            # Verify astore was called
-            mock_cache.astore.assert_called_once()
+        # Verify set was called
+        mock_client.set.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_handles_missing_tool_name(self) -> None:
@@ -492,24 +458,18 @@ class TestToolResultCacheMiddleware:
         mock_client = AsyncMock()
         config = ToolCacheConfig(redis_client=mock_client)
 
-        with patch(
-            "langgraph.middleware.redis.tool_cache.SemanticCache"
-        ) as mock_cache_class:
-            mock_cache = MagicMock()
-            mock_cache_class.return_value = mock_cache
+        middleware = ToolResultCacheMiddleware(config)
+        await middleware._ensure_initialized_async()
 
-            middleware = ToolResultCacheMiddleware(config)
-            await middleware._ensure_initialized_async()
+        async def mock_handler(request: dict) -> dict:
+            return {"result": "handled"}
 
-            async def mock_handler(request: dict) -> dict:
-                return {"result": "handled"}
+        # Request without tool_name
+        request = {"args": {"query": "test"}}
+        result = await middleware.awrap_tool_call(request, mock_handler)
 
-            # Request without tool_name
-            request = {"args": {"query": "test"}}
-            result = await middleware.awrap_tool_call(request, mock_handler)
-
-            # Should pass through to handler
-            assert result == {"result": "handled"}
+        # Should pass through to handler
+        assert result == {"result": "handled"}
 
     @pytest.mark.asyncio
     async def test_awrap_model_call_passes_through(self) -> None:
@@ -575,3 +535,276 @@ class TestToolResultCacheMiddleware:
         )
         assert isinstance(result, LangChainToolMessage)
         assert result.content == "not valid json {{{"
+
+    @pytest.mark.asyncio
+    async def test_no_ttl_set_without_config(self) -> None:
+        """Test that SET is called without EX when ttl_seconds is None."""
+        from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=None)
+        mock_client.set = AsyncMock()
+        config = ToolCacheConfig(redis_client=mock_client, ttl_seconds=None)
+
+        middleware = ToolResultCacheMiddleware(config)
+        await middleware._ensure_initialized_async()
+
+        async def mock_handler(
+            request: ToolCallRequest,
+        ) -> LangChainToolMessage:
+            return LangChainToolMessage(
+                content="data", name="search", tool_call_id="call_123"
+            )
+
+        request = _make_tool_call_request("search", args={"q": "test"})
+        await middleware.awrap_tool_call(request, mock_handler)
+
+        mock_client.set.assert_called_once()
+        call_kwargs = mock_client.set.call_args
+        assert "ex" not in call_kwargs.kwargs
+
+    @pytest.mark.asyncio
+    async def test_cache_key_includes_config_name(self) -> None:
+        """Test that cache key uses config name as prefix."""
+        from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
+
+        mock_client = AsyncMock()
+        config = ToolCacheConfig(redis_client=mock_client, name="mycache")
+        middleware = ToolResultCacheMiddleware(config)
+
+        request = _make_tool_call_request("search", args={"q": "test"})
+        cache_key = middleware._build_cache_key(request)
+        assert cache_key.startswith("mycache:")
+
+
+class TestVolatileArgDetectionUnit:
+    """Unit tests for _has_volatile_args helper."""
+
+    def _make_middleware(
+        self, volatile: set | None = None
+    ) -> "ToolResultCacheMiddleware":
+        from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
+
+        mock_client = AsyncMock()
+        config = ToolCacheConfig(redis_client=mock_client, volatile_arg_names=volatile)
+        return ToolResultCacheMiddleware(config)
+
+    def test_top_level_volatile_arg(self) -> None:
+        mw = self._make_middleware({"timestamp", "now"})
+        assert mw._has_volatile_args({"query": "x", "timestamp": 123}) is True
+
+    def test_nested_volatile_arg(self) -> None:
+        mw = self._make_middleware({"date"})
+        assert mw._has_volatile_args({"filter": {"date": "2024-01-01"}}) is True
+
+    def test_no_match(self) -> None:
+        mw = self._make_middleware({"timestamp"})
+        assert mw._has_volatile_args({"query": "x", "limit": 10}) is False
+
+    def test_empty_args(self) -> None:
+        mw = self._make_middleware({"timestamp"})
+        assert mw._has_volatile_args({}) is False
+
+    def test_disabled_none(self) -> None:
+        mw = self._make_middleware(None)
+        assert mw._has_volatile_args({"timestamp": 123}) is False
+
+    def test_disabled_empty_set(self) -> None:
+        mw = self._make_middleware(set())
+        assert mw._has_volatile_args({"timestamp": 123}) is False
+
+    def test_volatile_in_list_of_dicts(self) -> None:
+        mw = self._make_middleware({"timestamp"})
+        assert (
+            mw._has_volatile_args({"items": [{"timestamp": 123, "val": "x"}]}) is True
+        )
+
+    def test_volatile_in_tuple_of_dicts(self) -> None:
+        mw = self._make_middleware({"date"})
+        assert mw._has_volatile_args({"entries": ({"date": "2024-01-01"},)}) is True
+
+    def test_list_without_volatile_no_match(self) -> None:
+        mw = self._make_middleware({"timestamp"})
+        assert mw._has_volatile_args({"items": [{"name": "a"}, {"name": "b"}]}) is False
+
+
+class TestIgnoredArgsUnit:
+    """Unit tests for _strip_ignored_args helper."""
+
+    def _make_middleware(
+        self, ignored: set | None = None
+    ) -> "ToolResultCacheMiddleware":
+        from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
+
+        mock_client = AsyncMock()
+        config = ToolCacheConfig(redis_client=mock_client, ignored_arg_names=ignored)
+        return ToolResultCacheMiddleware(config)
+
+    def test_strips_ignored_keys(self) -> None:
+        mw = self._make_middleware({"request_id", "trace_id"})
+        result = mw._strip_ignored_args(
+            {"query": "x", "request_id": "r1", "trace_id": "t1"}
+        )
+        assert result == {"query": "x"}
+
+    def test_none_config_returns_original(self) -> None:
+        mw = self._make_middleware(None)
+        args = {"query": "x", "request_id": "r1"}
+        assert mw._strip_ignored_args(args) is args
+
+    def test_empty_set_returns_original(self) -> None:
+        mw = self._make_middleware(set())
+        args = {"query": "x", "request_id": "r1"}
+        assert mw._strip_ignored_args(args) is args
+
+    def test_partial_keys_only_strips_matching(self) -> None:
+        mw = self._make_middleware({"trace_id"})
+        result = mw._strip_ignored_args({"query": "x", "trace_id": "t1", "page": 1})
+        assert result == {"query": "x", "page": 1}
+
+    def test_none_args_returns_empty_dict(self) -> None:
+        mw = self._make_middleware({"request_id"})
+        assert mw._strip_ignored_args(None) == {}  # type: ignore[arg-type]
+
+    def test_non_dict_args_returns_empty_dict(self) -> None:
+        mw = self._make_middleware({"request_id"})
+        assert mw._strip_ignored_args("not a dict") == {}  # type: ignore[arg-type]
+
+
+class TestSideEffectPrefixUnit:
+    """Unit tests for _has_side_effect_prefix helper."""
+
+    def _make_middleware(
+        self, prefixes: tuple | None = None
+    ) -> "ToolResultCacheMiddleware":
+        from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
+
+        mock_client = AsyncMock()
+        config = ToolCacheConfig(
+            redis_client=mock_client, side_effect_prefixes=prefixes
+        )
+        return ToolResultCacheMiddleware(config)
+
+    def test_matching_prefix(self) -> None:
+        mw = self._make_middleware(("send_", "delete_"))
+        assert mw._has_side_effect_prefix("send_email") is True
+        assert mw._has_side_effect_prefix("delete_record") is True
+
+    def test_non_matching_prefix(self) -> None:
+        mw = self._make_middleware(("send_", "delete_"))
+        assert mw._has_side_effect_prefix("get_data") is False
+        assert mw._has_side_effect_prefix("search") is False
+
+    def test_custom_prefixes(self) -> None:
+        mw = self._make_middleware(("exec_", "run_"))
+        assert mw._has_side_effect_prefix("exec_query") is True
+        assert mw._has_side_effect_prefix("run_job") is True
+        assert mw._has_side_effect_prefix("send_email") is False
+
+    def test_disabled_none(self) -> None:
+        mw = self._make_middleware(None)
+        assert mw._has_side_effect_prefix("send_email") is False
+
+    def test_disabled_empty_tuple(self) -> None:
+        mw = self._make_middleware(())
+        assert mw._has_side_effect_prefix("send_email") is False
+
+
+class TestCacheabilityPrecedenceUnit:
+    """Unit tests for the full _is_tool_cacheable priority chain."""
+
+    def _make_middleware(self, **kwargs: object) -> "ToolResultCacheMiddleware":
+        from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
+
+        mock_client = AsyncMock()
+        config = ToolCacheConfig(redis_client=mock_client, **kwargs)
+        return ToolResultCacheMiddleware(config)
+
+    def test_cacheable_overrides_destructive(self) -> None:
+        mw = self._make_middleware()
+        mock_tool = MagicMock()
+        mock_tool.metadata = {"cacheable": True, "destructive": True}
+        req = _make_tool_call_request("delete_user", tool=mock_tool)
+        assert mw._is_tool_cacheable(req) is True
+
+    def test_destructive_overrides_read_only_idempotent(self) -> None:
+        mw = self._make_middleware()
+        mock_tool = MagicMock()
+        mock_tool.metadata = {
+            "destructive": True,
+            "read_only": True,
+            "idempotent": True,
+        }
+        req = _make_tool_call_request("tool", tool=mock_tool)
+        assert mw._is_tool_cacheable(req) is False
+
+    def test_volatile_metadata_prevents_caching(self) -> None:
+        mw = self._make_middleware()
+        mock_tool = MagicMock()
+        mock_tool.metadata = {"volatile": True}
+        req = _make_tool_call_request("get_time", tool=mock_tool)
+        assert mw._is_tool_cacheable(req) is False
+
+    def test_read_only_idempotent_enables_caching(self) -> None:
+        mw = self._make_middleware()
+        mock_tool = MagicMock()
+        mock_tool.metadata = {"read_only": True, "idempotent": True}
+        req = _make_tool_call_request("fetch_data", tool=mock_tool)
+        assert mw._is_tool_cacheable(req) is True
+
+    def test_side_effect_prefix_prevents_caching(self) -> None:
+        mw = self._make_middleware(side_effect_prefixes=("send_", "delete_"))
+        req = _make_tool_call_request("send_email")
+        assert mw._is_tool_cacheable(req) is False
+
+    def test_volatile_args_prevent_caching(self) -> None:
+        mw = self._make_middleware(volatile_arg_names={"timestamp"})
+        req = _make_tool_call_request("search", args={"query": "x", "timestamp": 123})
+        assert mw._is_tool_cacheable(req) is False
+
+    def test_no_new_features_falls_through_to_config(self) -> None:
+        mw = self._make_middleware(cacheable_tools=["search"])
+        req = _make_tool_call_request("search", args={"query": "x"})
+        assert mw._is_tool_cacheable(req) is True
+
+        req2 = _make_tool_call_request("unknown_tool", args={"x": 1})
+        assert mw._is_tool_cacheable(req2) is False
+
+
+class TestBuildCacheKeyWithIgnoredArgs:
+    """Unit tests for _build_cache_key with ignored_arg_names."""
+
+    def _make_middleware(
+        self, ignored: set | None = None
+    ) -> "ToolResultCacheMiddleware":
+        from langgraph.middleware.redis.tool_cache import ToolResultCacheMiddleware
+
+        mock_client = AsyncMock()
+        config = ToolCacheConfig(redis_client=mock_client, ignored_arg_names=ignored)
+        return ToolResultCacheMiddleware(config)
+
+    def test_ignored_args_stripped_from_key(self) -> None:
+        mw = self._make_middleware({"request_id"})
+        req1 = _make_tool_call_request(
+            "search", args={"query": "x", "request_id": "r1"}
+        )
+        req2 = _make_tool_call_request(
+            "search", args={"query": "x", "request_id": "r2"}
+        )
+        assert mw._build_cache_key(req1) == mw._build_cache_key(req2)
+
+    def test_non_ignored_args_differ(self) -> None:
+        mw = self._make_middleware({"request_id"})
+        req1 = _make_tool_call_request(
+            "search", args={"query": "x", "request_id": "r1"}
+        )
+        req2 = _make_tool_call_request(
+            "search", args={"query": "y", "request_id": "r1"}
+        )
+        assert mw._build_cache_key(req1) != mw._build_cache_key(req2)
+
+    def test_no_ignored_args_includes_all(self) -> None:
+        mw = self._make_middleware(None)
+        req = _make_tool_call_request("search", args={"query": "x", "request_id": "r1"})
+        key = mw._build_cache_key(req)
+        assert "request_id" in key


### PR DESCRIPTION
… tool annotations

- Add three opt-in config fields to ToolCacheConfig for fine-grained tool
- cache control: volatile_arg_names (skip caching for temporal args),
- ignored_arg_names (strip per-request noise from cache keys), and
- side_effect_prefixes (never cache mutating tools by name prefix).
- Expand the cacheability priority chain to recognize MCP-style metadata
- annotations (destructive, volatile, read_only/idempotent) alongside the
- existing cacheable flag and config whitelist/blacklist.
- Remove exact-match guard from semantic_cache.py awrap_model_call
- Update ToolCacheConfig docstring (distance_threshold/vectorizer now ignored)