### PR TITLE
fix(docs): replace broken sphinx-multiversion with plain sphinx-build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,36 +46,103 @@ jobs:
       - name: Install docs dependencies
         run: pip install -r docs/requirements.txt
 
-      - name: Copy example notebooks
-        run: python docs/copy_notebooks.py
-
       - name: Build versioned documentation
-        run: sphinx-multiversion docs docs/_build/html
-
-      - name: Create root redirect
         run: |
-          # Find the latest tag that matches our whitelist, fall back to main
-          LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v0\.4\.([1-9][0-9]*)$|^v0\.([5-9]|[0-9]{2,})\.[0-9]+$|^v[1-9][0-9]*\.[0-9]+\.[0-9]+$' | head -1)
+          set -e
+          OUTPUT_DIR="docs/_build/html"
+          mkdir -p "$OUTPUT_DIR"
+
+          # Tag regex: match v0.4.1+ and v1.0.0+ (v0.4.0 and earlier lack docs/)
+          TAG_REGEX='^v0\.4\.([1-9][0-9]*)$|^v0\.([5-9]|[0-9]{2,})\.[0-9]+$|^v[1-9][0-9]*\.[0-9]+\.[0-9]+$'
+
+          # Collect matching tags (newest first)
+          TAGS=$(git tag --sort=-v:refname | grep -E "$TAG_REGEX" || true)
+
+          # Track versions for versions.json
+          VERSIONS_JSON='[]'
+          LATEST_TAG=""
+
+          # Build docs for each matching tag
+          for tag in $TAGS; do
+            echo "=== Building docs for tag: $tag ==="
+            # Check if this tag has a docs/ directory
+            if ! git ls-tree --name-only "$tag" -- docs/ > /dev/null 2>&1; then
+              echo "    Skipping $tag (no docs/ directory)"
+              continue
+            fi
+
+            git checkout "$tag" -- docs/ examples/ || git checkout "$tag" -- docs/
+            python docs/copy_notebooks.py || true
+            sphinx-build -b html docs "$OUTPUT_DIR/$tag"
+            git checkout HEAD -- docs/ examples/ 2>/dev/null || git checkout HEAD -- docs/
+
+            if [ -z "$LATEST_TAG" ]; then
+              LATEST_TAG="$tag"
+            fi
+            VERSIONS_JSON=$(echo "$VERSIONS_JSON" | python3 -c "
+          import json, sys
+          v = json.load(sys.stdin)
+          v.append({'name': '$tag', 'tag': True})
+          print(json.dumps(v))")
+          done
+
+          # Build docs for main (current HEAD)
+          echo "=== Building docs for main ==="
+          git checkout HEAD -- docs/ examples/ 2>/dev/null || true
+          python docs/copy_notebooks.py
+          sphinx-build -b html docs "$OUTPUT_DIR/main"
+
+          VERSIONS_JSON=$(echo "$VERSIONS_JSON" | python3 -c "
+          import json, sys
+          v = json.load(sys.stdin)
+          v.append({'name': 'main', 'tag': False})
+          print(json.dumps(v))")
+
+          # Determine redirect target
           TARGET="${LATEST_TAG:-main}"
-          cat > docs/_build/html/index.html << 'REDIRECT_EOF'
+
+          # Write versions.json
+          python3 -c "
+          import json
+          versions = json.loads('$VERSIONS_JSON')
+          data = {'versions': versions, 'latest': '${LATEST_TAG}', 'current': ''}
+          with open('$OUTPUT_DIR/versions.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+
+          # Inject current version into each build's versions.json copy
+          for dir in "$OUTPUT_DIR"/*/; do
+            name=$(basename "$dir")
+            cp "$OUTPUT_DIR/versions.json" "$dir/versions.json"
+            python3 -c "
+          import json
+          with open('$dir/versions.json') as f:
+              data = json.load(f)
+          data['current'] = '$name'
+          with open('$dir/versions.json', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+          done
+
+          # Create root redirect
+          cat > "$OUTPUT_DIR/index.html" << REDIRECT_EOF
           <!DOCTYPE html>
           <html>
           <head>
             <meta charset="utf-8">
             <title>Redirecting...</title>
-            <script>
-              // Redirect to latest tagged version, or main if none exist
-              var defined_target = "DEFINED_TARGET_PLACEHOLDER";
-              window.location.href = defined_target + "/index.html";
-            </script>
-            <meta http-equiv="refresh" content="0; url=DEFINED_TARGET_PLACEHOLDER/index.html">
+            <meta http-equiv="refresh" content="0; url=${TARGET}/index.html">
           </head>
           <body>
-            <p>Redirecting to <a href="DEFINED_TARGET_PLACEHOLDER/index.html">latest documentation</a>...</p>
+            <p>Redirecting to <a href="${TARGET}/index.html">latest documentation</a>...</p>
           </body>
           </html>
           REDIRECT_EOF
-          sed -i "s|DEFINED_TARGET_PLACEHOLDER|${TARGET}|g" docs/_build/html/index.html
+
+          echo "=== Build complete ==="
+          echo "Versions built:"
+          ls -d "$OUTPUT_DIR"/*/
+          echo "Root redirects to: $TARGET"
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install format lint test test-all test-sentinel clean redis-start redis-stop check-types check docs docs-clean docs-serve docs-multi
+.PHONY: install format lint test test-all test-sentinel clean redis-start redis-stop check-types check docs docs-clean docs-serve
 
 install:
 	poetry install --all-extras
@@ -48,10 +48,6 @@ docs:
 docs-clean:
 	rm -rf docs/_build
 	rm -rf docs/examples/checkpoints docs/examples/human_in_the_loop docs/examples/memory docs/examples/middleware docs/examples/react_agent
-
-docs-multi:
-	python docs/copy_notebooks.py
-	sphinx-multiversion docs docs/_build/html
 
 docs-serve: docs
 	python -m http.server 8085 --directory docs/_build/html

--- a/docs/_templates/versioning.html
+++ b/docs/_templates/versioning.html
@@ -1,23 +1,46 @@
-{% if versions %}
 <div class="version-switcher">
   <h4>Version</h4>
-  <select onchange="if (this.value) window.location.href = this.value;">
-    {%- for item in versions.tags %}
-    <option
-      value="{{ vpathto(item.name) }}"
-      {% if item.name == current_version.name %}selected{% endif %}
-    >
-      {{ item.name }}{% if loop.first %} (latest){% endif %}
-    </option>
-    {%- endfor %}
-    {%- for item in versions.branches %}
-    <option
-      value="{{ vpathto(item.name) }}"
-      {% if item.name == current_version.name %}selected{% endif %}
-    >
-      {{ item.name }}{% if item.name == "main" %} (dev){% endif %}
-    </option>
-    {%- endfor %}
+  <select id="version-select" onchange="if (this.value) window.location.href = this.value;">
+    <option selected>Loading...</option>
   </select>
 </div>
-{% endif %}
+<script>
+(function() {
+  // Walk up from current page to find versions.json at the site root
+  var depth = window.location.pathname.replace(/\/+$/, '').split('/').length - 1;
+  // Try relative paths — handles both GitHub Pages subpath and root deployments
+  var candidates = [];
+  for (var i = 0; i <= depth; i++) {
+    candidates.push('../'.repeat(i) + 'versions.json');
+  }
+
+  function tryFetch(urls) {
+    if (urls.length === 0) return;
+    var url = urls.shift();
+    fetch(url).then(function(r) {
+      if (!r.ok) throw new Error(r.status);
+      return r.json();
+    }).then(populate).catch(function() { tryFetch(urls); });
+  }
+
+  function populate(data) {
+    var sel = document.getElementById('version-select');
+    sel.innerHTML = '';
+    var current = data.current || '';
+    data.versions.forEach(function(v) {
+      var opt = document.createElement('option');
+      var label = v.name;
+      if (v.tag) label += v.name === data.latest ? ' (latest)' : '';
+      else label += ' (dev)';
+      opt.textContent = label;
+      // Build path relative to site root
+      var base = url.replace('versions.json', '');
+      opt.value = base + v.name + '/';
+      if (v.name === current) opt.selected = true;
+      sel.appendChild(opt);
+    });
+  }
+
+  tryFetch(candidates);
+})();
+</script>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,6 @@ extensions = [
     "_extension.gallery_directive",
     "myst_nb",
     "sphinx_favicon",
-    "sphinx_multiversion",
 ]
 
 templates_path = ["_templates"]
@@ -99,14 +98,6 @@ favicons = [
     "Redis_Favicon_16x16_Red.png",
     "Redis_Favicon_144x144_Red.png",
 ]
-
-# -- sphinx-multiversion options ---------------------------------------------
-# Tag whitelist: match v0.4.1+ and v1.0.0+ (v0.4.0 and earlier lack docs/)
-smv_tag_whitelist = r"^v0\.4\.([1-9]\d*)$|^v0\.([5-9]|\d{2,})\.\d+$|^v([1-9]\d*)\.\d+\.\d+$"
-smv_branch_whitelist = r"^main$"
-smv_remote_whitelist = r"^origin$"
-smv_released_pattern = r"^refs/tags/.*$"
-smv_outputdir_format = "{ref.name}"
 
 # -- Sidebar with version switcher ------------------------------------------
 html_sidebars = {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,4 @@ myst-nb>=1.0
 sphinx-design>=0.5
 sphinx-copybutton>=0.5
 sphinx-favicon>=1.0
-sphinx-multiversion-contrib>=0.2.13
 pyyaml>=6.0


### PR DESCRIPTION
## Summary

The entire `sphinx-multiversion` ecosystem (original package + all forks including `sphinx-multiversion-contrib`) is broken with Sphinx 7+ due to an incompatible `Config.read()` API change. This replaces it with a straightforward CI workflow that runs `sphinx-build` once per matching tag and once for `main`.

## Changes

- **`docs/requirements.txt`**: Remove `sphinx-multiversion-contrib`
- **`docs/conf.py`**: Remove `sphinx_multiversion` extension and all `smv_*` config
- **`.github/workflows/docs.yml`**: Rewrite build step to loop over matching tags (v0.4.1+) and `main`, running `sphinx-build` for each. Generates `versions.json` for the sidebar dropdown and a root `index.html` redirect
- **`docs/_templates/versioning.html`**: Rewrite to fetch `versions.json` at runtime instead of relying on Jinja2 context from sphinx-multiversion
- **`Makefile`**: Remove `docs-multi` target (versioned builds are CI-only; local `make docs` still works for single-version)

## Output structure (unchanged)

```
docs/_build/html/
  index.html          <- redirect to latest tag or main
  versions.json       <- version metadata
  main/               <- dev docs
  v0.4.1/             <- future tagged release docs
```

## Test plan

- [ ] CI workflow passes (no sphinx-multiversion dependency)
- [ ] `main/` docs build and deploy
- [ ] Version switcher dropdown renders in sidebar
- [ ] Root URL redirects to `main/` (no qualifying tags yet)
- [ ] Next release (v0.4.1+) will appear in dropdown automatically