### PR TITLE
fix(docs): replace sphinx-multiversion and fix CI build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
         run: poetry install --all-extras
 
       - name: Install docs dependencies
-        run: pip install -r docs/requirements.txt
+        run: poetry run pip install -r docs/requirements.txt
 
       - name: Build versioned documentation
         run: |
@@ -72,8 +72,8 @@ jobs:
             fi
 
             git checkout "$tag" -- docs/ examples/ || git checkout "$tag" -- docs/
-            python docs/copy_notebooks.py || true
-            sphinx-build -b html docs "$OUTPUT_DIR/$tag"
+            poetry run python docs/copy_notebooks.py || true
+            poetry run sphinx-build -b html docs "$OUTPUT_DIR/$tag"
             git checkout HEAD -- docs/ examples/ 2>/dev/null || git checkout HEAD -- docs/
 
             if [ -z "$LATEST_TAG" ]; then
@@ -89,8 +89,8 @@ jobs:
           # Build docs for main (current HEAD)
           echo "=== Building docs for main ==="
           git checkout HEAD -- docs/ examples/ 2>/dev/null || true
-          python docs/copy_notebooks.py
-          sphinx-build -b html docs "$OUTPUT_DIR/main"
+          poetry run python docs/copy_notebooks.py
+          poetry run sphinx-build -b html docs "$OUTPUT_DIR/main"
 
           VERSIONS_JSON=$(echo "$VERSIONS_JSON" | python3 -c "
           import json, sys


### PR DESCRIPTION
## Summary

Two fixes for the broken docs CI:

1. **Remove sphinx-multiversion entirely** — the entire ecosystem (original + all forks) is broken with Sphinx 7+ due to an incompatible `Config.read()` API change. Replaced with a CI workflow that runs `sphinx-build` once per matching tag and once for `main`.

2. **Run sphinx-build inside poetry venv** — `conf.py` imports `langgraph.checkpoint.redis.version` which pulls in `orjson`. Docs deps and sphinx-build must run through `poetry run` so project packages are available.

## Changes

- **`docs/requirements.txt`**: Remove `sphinx-multiversion-contrib`
- **`docs/conf.py`**: Remove `sphinx_multiversion` extension and `smv_*` config
- **`.github/workflows/docs.yml`**: Replace sphinx-multiversion with per-ref `sphinx-build` loop; use `poetry run` for all Python commands
- **`docs/_templates/versioning.html`**: Fetch `versions.json` at runtime instead of Jinja2 context
- **`Makefile`**: Remove `docs-multi` target

## Test plan

- [ ] CI docs workflow passes
- [ ] `main/` docs build and deploy to GitHub Pages
- [ ] Root URL redirects to `main/`
- [ ] Version switcher renders in sidebar