### PR TITLE
fix(checkpoint): base64-decode pending send blobs before deserialization

### DIFF
--- a/langgraph/checkpoint/redis/base.py
+++ b/langgraph/checkpoint/redis/base.py
@@ -211,7 +211,14 @@ class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexTyp
         return {
             **loaded,
             "pending_sends": [
-                self.serde.loads_typed((safely_decode(c), b))
+                # Blobs are stored base64-encoded in Redis JSON (see _encode_blob),
+                # so they must be decoded before deserialization, exactly as the
+                # pending_writes path does via _load_writes. The pending_sends
+                # loaders return the raw base64 blob, so decode it here at the
+                # single point where every variant (sync/async, single/batch)
+                # funnels through. Without this, loads_typed feeds a base64 string
+                # to orjson and raises JSONDecodeError on resume.
+                self.serde.loads_typed((safely_decode(c), self._decode_blob(b)))
                 for c, b in pending_sends or []
             ],
             "channel_values": channel_values,

--- a/tests/test_pending_sends_base64_decode.py
+++ b/tests/test_pending_sends_base64_decode.py
@@ -1,0 +1,103 @@
+"""Regression test: pending-send blobs must be base64-decoded on load.
+
+Blobs are stored base64-encoded in Redis JSON (see ``BaseRedisSaver._encode_blob``).
+The pending-writes load path decodes them via ``_decode_blob`` before
+deserialization, but the pending-sends load path returned the raw base64 string.
+``_load_checkpoint`` then handed that string to the serializer, and ``orjson``
+raised on the first (non-JSON) character::
+
+    orjson.JSONDecodeError: unexpected character: line 1 column 1 (char 0)
+
+This broke resuming any graph that left a queued ``Send`` on the TASKS channel
+(e.g. a human-in-the-loop ``interrupt()`` or a map step) when the checkpoint was
+read back through the FT.SEARCH load path.
+
+These tests store a real ``Send`` on a parent checkpoint's TASKS channel and
+confirm it round-trips back to a ``Send`` object through ``_load_checkpoint``.
+"""
+
+import uuid
+
+import pytest
+from langgraph.constants import TASKS
+from langgraph.types import Send
+
+from langgraph.checkpoint.redis import RedisSaver
+from langgraph.checkpoint.redis.aio import AsyncRedisSaver
+
+
+def _checkpoint(checkpoint_id: str) -> dict:
+    return {
+        "id": checkpoint_id,
+        "ts": "2024-01-01T00:00:00",
+        "v": 1,
+        "channel_values": {"messages": []},
+        "channel_versions": {"messages": "1"},
+        "versions_seen": {},
+        "pending_sends": [],
+    }
+
+
+def test_pending_sends_blob_is_base64_decoded_sync(redis_url: str) -> None:
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        thread_id = f"test-pending-sends-{uuid.uuid4()}"
+        base = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+
+        parent_id = str(uuid.uuid4())
+        parent_cfg = saver.put(
+            base, _checkpoint(parent_id), {"source": "loop"}, {"messages": "1"}
+        )
+        # A queued Send on the parent's TASKS channel, as an interrupt leaves behind.
+        saver.put_writes(
+            parent_cfg, [(TASKS, Send("tools", {"request": "approve?"}))], "task1"
+        )
+
+        # FT.SEARCH load path returns the stored (type, blob) pairs (blob is base64).
+        pending_sends = saver._load_pending_sends(thread_id, "", parent_id)
+        assert pending_sends, "expected the TASKS write to be loaded as a pending send"
+
+        # _load_checkpoint is the single point that deserializes pending sends.
+        # Before the fix this raised orjson.JSONDecodeError on the base64 blob.
+        checkpoint = saver._load_checkpoint(_checkpoint(parent_id), {}, pending_sends)
+
+        sends = checkpoint["pending_sends"]
+        assert len(sends) == 1
+        assert isinstance(sends[0], Send)
+        assert sends[0].node == "tools"
+        assert sends[0].arg == {"request": "approve?"}
+
+        saver.delete_thread(thread_id)
+
+
+@pytest.mark.asyncio
+async def test_pending_sends_blob_is_base64_decoded_async(redis_url: str) -> None:
+    async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
+        await saver.asetup()
+        thread_id = f"test-pending-sends-{uuid.uuid4()}"
+        base = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+
+        parent_id = str(uuid.uuid4())
+        parent_cfg = await saver.aput(
+            base, _checkpoint(parent_id), {"source": "loop"}, {"messages": "1"}
+        )
+        await saver.aput_writes(
+            parent_cfg, [(TASKS, Send("tools", {"request": "approve?"}))], "task1"
+        )
+
+        # _abatch_load_pending_sends uses the FT.SEARCH ($.blob) path resume hits.
+        pending_sends_map = await saver._abatch_load_pending_sends(
+            [(thread_id, "", parent_id)]
+        )
+        pending_sends = pending_sends_map.get((thread_id, "", parent_id), [])
+        assert pending_sends, "expected the TASKS write to be loaded as a pending send"
+
+        checkpoint = saver._load_checkpoint(_checkpoint(parent_id), {}, pending_sends)
+
+        sends = checkpoint["pending_sends"]
+        assert len(sends) == 1
+        assert isinstance(sends[0], Send)
+        assert sends[0].node == "tools"
+        assert sends[0].arg == {"request": "approve?"}
+
+        await saver.adelete_thread(thread_id)


### PR DESCRIPTION
## What

Base64-decode pending-send blobs before deserialization, fixing an `orjson.JSONDecodeError` when resuming a graph that has a queued `Send` on the TASKS channel (human-in-the-loop `interrupt()`, map/`Send` steps).

Closes #191.

## Root cause

Blobs are stored base64-encoded in Redis JSON (`_encode_blob`). The `pending_writes` load path decodes them with `_decode_blob`, but the `pending_sends` load path returned the raw base64 string. `_load_checkpoint` then handed that string to `loads_typed` → `orjson.loads`, which fails on the first non-JSON character:

```
orjson.JSONDecodeError: unexpected character: line 1 column 1 (char 0)
```

## Fix

One change at the single point where every pending-sends variant (sync/async, single/batch) is deserialized `BaseRedisSaver._load_checkpoint`  mirroring `_load_writes`:

```python
self.serde.loads_typed((safely_decode(c), self._decode_blob(b)))
```

This covers `RedisSaver` and `AsyncRedisSaver` and all of `_load_pending_sends` / `_aload_pending_sends` / `_(a)batch_load_pending_sends`. Shallow savers are unaffected (they always pass `pending_sends=[]`).

## Tests

Adds `tests/test_pending_sends_base64_decode.py` with sync and async integration tests that store a real `Send` on a parent checkpoint's TASKS channel and assert it round-trips back to a `Send` through `_load_checkpoint`. Both tests fail before the fix (with the exact `JSONDecodeError`) and pass after.
