### PR TITLE
Fix: Removed dependency on private constructor helper 

### DIFF
--- a/langgraph/checkpoint/redis/jsonplus_redis.py
+++ b/langgraph/checkpoint/redis/jsonplus_redis.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import orjson
@@ -68,11 +69,34 @@ class JsonPlusRedisSerializer(JsonPlusSerializer):
         "parent_checkpoint_id",
     ]
 
+    def _encode_constructor_envelope(
+        self,
+        constructor: Callable[..., Any] | type[Any],
+        *,
+        args: Sequence[Any] | None = None,
+        kwargs: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Build an lc:2 default-constructor envelope.
+
+        This preserves type information for JSON values that should be revived
+        by calling the target class constructor.
+        """
+        out: dict[str, Any] = {
+            "lc": 2,
+            "type": "constructor",
+            "id": [*constructor.__module__.split("."), constructor.__name__],
+        }
+        if args is not None:
+            out["args"] = args
+        if kwargs is not None:
+            out["kwargs"] = kwargs
+        return out
+
     def _default_handler(self, obj: Any) -> Any:
         """Custom JSON encoder for objects that orjson can't serialize.
 
-        This handles LangChain objects by delegating to the parent's
-        _encode_constructor_args method which creates the LC format.
+        This handles LangChain objects by encoding them in the LC constructor
+        format that the loader can revive.
         """
         # Bytes/bytearray in nested structures require msgpack - signal to fallback
         if isinstance(obj, (bytes, bytearray)):
@@ -94,10 +118,10 @@ class JsonPlusRedisSerializer(JsonPlusSerializer):
                 "arg": obj.arg,
             }
 
-        # Try to encode using parent's constructor args encoder
+        # Try to encode using the constructor envelope format.
         # This creates the {"lc": 2, "type": "constructor", ...} format
         try:
-            # _encode_constructor_args needs the CLASS, not the instance
+            # The envelope needs the CLASS, not the instance.
             # For LangChain objects with to_json(), use that data for kwargs
             if hasattr(obj, "to_json"):
                 json_dict = obj.to_json()
@@ -107,7 +131,7 @@ class JsonPlusRedisSerializer(JsonPlusSerializer):
 
             # For other objects, encode with constructor args
             # Pass the class and the instance's __dict__ as kwargs
-            return self._encode_constructor_args(
+            return self._encode_constructor_envelope(
                 type(obj), kwargs=obj.__dict__ if hasattr(obj, "__dict__") else {}
             )
         except (AttributeError, KeyError, ValueError, TypeError):
@@ -152,7 +176,7 @@ class JsonPlusRedisSerializer(JsonPlusSerializer):
                 k: self._preprocess_interrupts(v)
                 for k, v in dataclasses.asdict(obj).items()
             }
-            return self._encode_constructor_args(type(obj), kwargs=processed_dict)
+            return self._encode_constructor_envelope(type(obj), kwargs=processed_dict)
         elif isinstance(obj, dict):
             return {k: self._preprocess_interrupts(v) for k, v in obj.items()}
         elif isinstance(obj, (list, tuple)):
@@ -218,7 +242,7 @@ class JsonPlusRedisSerializer(JsonPlusSerializer):
     def _reconstruct_from_constructor(self, obj: dict[str, Any]) -> Any:
         """Reconstruct an object from LangChain constructor format.
 
-        This handles objects that were serialized using _encode_constructor_args
+        This handles objects that were serialized using the lc:2 constructor envelope
         but are not LangChain objects (e.g., dataclasses, regular classes, sets).
 
         Args:

--- a/tests/test_jsonplus_redis_constructor_envelope.py
+++ b/tests/test_jsonplus_redis_constructor_envelope.py
@@ -1,0 +1,74 @@
+"""Regression tests for issue #189 JsonPlusRedisSerializer compatibility."""
+
+import dataclasses
+from uuid import uuid4
+
+import pytest
+from langgraph.checkpoint.base import CheckpointMetadata, empty_checkpoint
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+from langgraph.checkpoint.redis import RedisSaver
+from langgraph.checkpoint.redis.jsonplus_redis import JsonPlusRedisSerializer
+
+
+@dataclasses.dataclass
+class ConstructorEnvelopePayload:
+    value: str
+
+
+def test_dataclass_roundtrip_when_constructor_helper_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tests that dataclass payloads roundtrip without the checkpoint helper.
+
+    Intended behavior: JsonPlusRedisSerializer should preserve dataclass type
+    information using its JSON constructor envelope even when the inherited
+    checkpoint serializer does not provide a constructor helper.
+    """
+    monkeypatch.delattr(
+        JsonPlusSerializer,
+        "_encode_constructor_args",
+        raising=False,
+    )
+
+    serializer = JsonPlusRedisSerializer()
+    type_str, data_bytes = serializer.dumps_typed(
+        {"payload": ConstructorEnvelopePayload(value="ok")}
+    )
+    result = serializer.loads_typed((type_str, data_bytes))
+
+    assert type_str == "json"
+    assert result["payload"] == ConstructorEnvelopePayload(value="ok")
+
+
+def test_checkpoint_dataclass_state_roundtrip(
+    redis_url: str,
+) -> None:
+    """Tests that dataclass checkpoint state roundtrips through Redis.
+
+    Intended behavior: RedisSaver should persist and restore dataclass channel
+    values as their original type, not as plain dictionaries.
+    """
+    checkpoint = empty_checkpoint()
+    checkpoint["channel_values"] = {
+        "context": ConstructorEnvelopePayload(value="persisted")
+    }
+    checkpoint["channel_versions"] = {"context": "1"}
+
+    thread_id = f"constructor-envelope-{uuid4()}"
+    config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+    metadata: CheckpointMetadata = {"source": "test", "step": 1, "writes": {}}
+
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        saved_config = saver.put(
+            config,
+            checkpoint,
+            metadata,
+            {"context": "1"},
+        )
+        restored = saver.get(saved_config)
+
+    assert restored is not None
+    payload = restored["channel_values"]["context"]
+    assert payload == ConstructorEnvelopePayload(value="persisted")


### PR DESCRIPTION
Fixes #189. 

### Summary
In `langgraph-checkpoint==4.1.1`, the private upstream `_encode_constructor_args` helper was removed, causing `JsonPlusRedisSerializer` checkpoint writes to raise an `AttributeError` when serializing dataclass payloads.

This PR fixes `JsonPlusRedisSerializer` compatibility with `langgraph-checkpoint==4.1.1`. 

### Fixes
The Redis serializer now builds its own `lc:2` default-constructor envelope for JSON-serialized objects, preserving dataclass type information without relying on upstream internals. 

### Tests
Added regression coverage for both direct serializer roundtrip behavior and Redis checkpoint persistence.