### PR TITLE
fix: escape RediSearch-special characters in store delete queries

### DIFF
--- a/langgraph/store/redis/aio.py
+++ b/langgraph/store/redis/aio.py
@@ -561,7 +561,7 @@ class AsyncRedisStore(
             # Delete matching documents
             for op in deletes:
                 prefix = _namespace_to_text(op.namespace)
-                query = f"(@prefix:{prefix} @key:{{{op.key}}})"
+                query = f"(@prefix:{prefix} @key:{{{_token_escaper.escape(op.key)}}})"
                 results = await self.store_index.search(query)
                 for doc in results.docs:
                     await self._redis.delete(doc.id)

--- a/langgraph/store/redis/base.py
+++ b/langgraph/store/redis/base.py
@@ -519,7 +519,7 @@ class BaseRedisStore(Generic[RedisClientType, IndexType]):
             # Delete matching documents
             for op in deletes:
                 prefix = _namespace_to_text(op.namespace)
-                query = f"(@prefix:{prefix} @key:{{{op.key}}})"
+                query = f"(@prefix:{prefix} @key:{{{_token_escaper.escape(op.key)}}})"
                 results = self.store_index.search(query)
                 for doc in results.docs:
                     self._redis.delete(doc.id)

--- a/tests/test_issue_196_store_delete_escaping.py
+++ b/tests/test_issue_196_store_delete_escaping.py
@@ -1,0 +1,43 @@
+"""Test for issue #196 — store delete must escape RediSearch-special key characters.
+
+The delete branch of ``_prepare_batch_PUT_queries`` / ``_aprepare_batch_PUT_queries``
+interpolated the raw item key into the FT.SEARCH query, so ``delete()`` /
+``adelete()`` raised ``RedisSearchError: ... SEARCH_SYNTAX Syntax error ...`` for
+any key containing characters RediSearch treats as query syntax (``-``, ``.``,
+``#``, ...). ``put()`` and ``get()`` accept such keys — filename-derived keys like
+``my-doc.md#0`` could be written but never deleted.
+"""
+
+from langgraph.store.redis import AsyncRedisStore, RedisStore
+
+NAMESPACE = ("issue196",)
+
+SPECIAL_KEYS = [
+    "my-doc.md#0",  # filename-derived key from the issue report
+    "a-b",  # '-' is the negation operator
+    "a.b",  # '.' is a token separator
+    "a#1",  # '#' breaks tag parsing
+    "user@example.com",  # '@' starts a field filter
+]
+
+
+def test_sync_store_delete_key_with_special_chars(redis_url: str) -> None:
+    with RedisStore.from_conn_string(redis_url) as store:
+        store.setup()
+        for key in SPECIAL_KEYS:
+            store.put(NAMESPACE, key, {"text": "hello"})
+            assert store.get(NAMESPACE, key) is not None
+            store.delete(NAMESPACE, key)  # raised RedisSearchError before the fix
+            assert store.get(NAMESPACE, key) is None
+
+
+async def test_async_store_adelete_key_with_special_chars(redis_url: str) -> None:
+    async with AsyncRedisStore.from_conn_string(redis_url) as store:
+        await store.setup()
+        for key in SPECIAL_KEYS:
+            await store.aput(NAMESPACE, key, {"text": "hello"})
+            assert await store.aget(NAMESPACE, key) is not None
+            await store.adelete(
+                NAMESPACE, key
+            )  # raised RedisSearchError before the fix
+            assert await store.aget(NAMESPACE, key) is None


### PR DESCRIPTION
Fixes #196

## Problem

`store.delete()` / `store.adelete()` raise `RedisSearchError: ... SEARCH_SYNTAX Syntax error ...` for any key containing characters RediSearch treats as query syntax (`-`, `.`, `#`, `@`, …). `put()`/`get()` accept such keys, so filename-derived keys like `my-doc.md#0` could be written but never deleted.

## Cause / fix

The delete branch of `_prepare_batch_PUT_queries` (base.py) and `_aprepare_batch_PUT_queries` (aio.py) interpolated the **raw** key into the FT.SEARCH query:

```python
query = f"(@prefix:{prefix} @key:{{{op.key}}})"
```

This PR escapes the key with `_token_escaper`, matching the already-correct query in `_batch_put_ops`:

```python
query = f"(@prefix:{prefix} @key:{{{_token_escaper.escape(op.key)}}})"
```

Two one-line changes (async + sync stores).

## Tests

`tests/test_issue_196_store_delete_escaping.py` — sync and async put → get → delete → get-is-None round-trips over five representative keys (`my-doc.md#0`, `a-b`, `a.b`, `a#1`, `user@example.com`). Both tests fail with the SEARCH_SYNTAX error before the fix and pass after; also verified manually against a `redis:8` container.
