### PR TITLE
fix(checkpoint): preserve DeltaChannel snapshots in Redis JSON

### DIFF
--- a/langgraph/checkpoint/redis/base.py
+++ b/langgraph/checkpoint/redis/base.py
@@ -302,27 +302,17 @@ class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexTyp
 
     def _msgpack_to_redis_json(self, value: Any) -> dict[str, Any]:
         """Convert a msgpack-deserialized checkpoint into Redis JSON-safe data."""
-        binary_safe = self._replace_binary_markers(value)
         serializer = cast(JsonPlusRedisSerializer, self.serde)
-        processed = serializer._preprocess_interrupts(binary_safe)
+        processed = serializer._preprocess_redis_json(
+            value,
+            encode_bytes=self._encode_blob,
+        )
         json_bytes = orjson.dumps(
             processed,
             default=serializer._default_handler,
             option=orjson.OPT_NON_STR_KEYS,
         )
         return cast(dict, orjson.loads(json_bytes))
-
-    def _replace_binary_markers(self, value: Any) -> Any:
-        """Recursively replace binary values with JSON-safe markers."""
-        if isinstance(value, bytes):
-            return {"__bytes__": self._encode_blob(value)}
-        if isinstance(value, dict):
-            return {k: self._replace_binary_markers(v) for k, v in value.items()}
-        if isinstance(value, list):
-            return [self._replace_binary_markers(item) for item in value]
-        if isinstance(value, tuple):
-            return tuple(self._replace_binary_markers(item) for item in value)
-        return value
 
     def _deserialize_channel_values(
         self, channel_values: dict[str, Any]
@@ -376,6 +366,14 @@ class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexTyp
             if "__bytes__" in obj and len(obj) == 1:
                 # Decode base64-encoded bytes
                 return self._decode_blob(obj["__bytes__"])
+
+            # Delegate _DeltaSnapshot markers to the serializer (issue #201).
+            if obj.get("__delta_snapshot__") is True:
+                if hasattr(self.serde, "_revive_if_needed"):
+                    revived = {
+                        k: self._recursive_deserialize(v) for k, v in obj.items()
+                    }
+                    return self.serde._revive_if_needed(revived)
 
             # Check if this is a Send object marker (issue #94)
             if (

--- a/langgraph/checkpoint/redis/jsonplus_redis.py
+++ b/langgraph/checkpoint/redis/jsonplus_redis.py
@@ -108,6 +108,11 @@ class JsonPlusRedisSerializer(JsonPlusSerializer):
         if isinstance(obj, Interrupt):
             return _serialize_interrupt(obj)
 
+        from langgraph.checkpoint.serde.types import _DeltaSnapshot
+
+        if isinstance(obj, _DeltaSnapshot):
+            return {"__delta_snapshot__": True, "value": obj.value}
+
         # Handle Send objects with a type marker (issue #94)
         from langgraph.types import Send
 
@@ -138,31 +143,72 @@ class JsonPlusRedisSerializer(JsonPlusSerializer):
             # For types we can't handle, raise TypeError
             raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
-    def _preprocess_interrupts(self, obj: Any) -> Any:
-        """Recursively add type markers to Interrupt and Send objects before serialization.
+    def _preprocess_redis_json(
+        self,
+        obj: Any,
+        *,
+        encode_bytes: Callable[[bytes], Any] | None = None,
+    ) -> Any:
+        """Recursively normalize values before Redis JSON encoding.
 
-        This prevents false positives where user data with {value, id} fields
-        could be incorrectly deserialized as Interrupt objects.
+        The order here is intentional:
 
-        Also handles dataclass instances to preserve type information during serialization.
+        1. Escape scalar values that Redis JSON cannot store directly, such as
+           bytes and bytearray, when an encode_bytes callback is provided.
+        2. Preserve allowlisted semantic/type-carrying values before treating
+           them as containers. This includes explicit Redis markers for
+           Interrupt, _DeltaSnapshot, and Send, plus constructor envelopes for
+           set and dataclass instances. This is especially important for
+           _DeltaSnapshot because it is a NamedTuple and would otherwise be
+           flattened by the generic tuple branch.
+        3. Recurse through ordinary containers only after those special cases
+           have had a chance to preserve their type information.
+
+        When encode_bytes is provided, nested bytes/bytearray values are escaped
+        as Redis JSON markers. Without it, bytes are left in place so orjson can
+        raise and dumps_typed can fall back to msgpack.
         """
+        from langgraph.checkpoint.serde.types import _DeltaSnapshot
         from langgraph.types import Interrupt, Send
 
+        if isinstance(obj, (bytes, bytearray)):
+            return (
+                {"__bytes__": encode_bytes(bytes(obj))}
+                if encode_bytes is not None
+                else obj
+            )
         if isinstance(obj, Interrupt):
-            return _serialize_interrupt(obj, preprocess=self._preprocess_interrupts)
+            return _serialize_interrupt(
+                obj,
+                preprocess=lambda value: self._preprocess_redis_json(
+                    value, encode_bytes=encode_bytes
+                ),
+            )
+        elif isinstance(obj, _DeltaSnapshot):
+            return {
+                "__delta_snapshot__": True,
+                "value": self._preprocess_redis_json(
+                    obj.value, encode_bytes=encode_bytes
+                ),
+            }
         elif isinstance(obj, Send):
             # Add type marker to distinguish from plain dicts (issue #94)
             return {
                 "__send__": True,
                 "node": obj.node,
-                "arg": self._preprocess_interrupts(obj.arg),
+                "arg": self._preprocess_redis_json(obj.arg, encode_bytes=encode_bytes),
             }
         elif isinstance(obj, set):
             # Handle sets by converting to list for JSON serialization
             # Will be reconstructed back to set on deserialization
             return self._encode_constructor_envelope(
                 set,
-                args=[[self._preprocess_interrupts(item) for item in obj]],
+                args=[
+                    [
+                        self._preprocess_redis_json(item, encode_bytes=encode_bytes)
+                        for item in obj
+                    ]
+                ],
             )
         elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
             # Handle dataclass instances (like langmem's RunningSummary)
@@ -170,14 +216,22 @@ class JsonPlusRedisSerializer(JsonPlusSerializer):
             # Recursively process the dataclass fields without dataclasses.asdict(),
             # which would erase nested dataclass type information.
             processed_dict = {
-                field.name: self._preprocess_interrupts(getattr(obj, field.name))
+                field.name: self._preprocess_redis_json(
+                    getattr(obj, field.name), encode_bytes=encode_bytes
+                )
                 for field in dataclasses.fields(obj)
             }
             return self._encode_constructor_envelope(type(obj), kwargs=processed_dict)
         elif isinstance(obj, dict):
-            return {k: self._preprocess_interrupts(v) for k, v in obj.items()}
+            return {
+                k: self._preprocess_redis_json(v, encode_bytes=encode_bytes)
+                for k, v in obj.items()
+            }
         elif isinstance(obj, (list, tuple)):
-            processed = [self._preprocess_interrupts(item) for item in obj]
+            processed = [
+                self._preprocess_redis_json(item, encode_bytes=encode_bytes)
+                for item in obj
+            ]
             # Preserve tuple type
             return tuple(processed) if isinstance(obj, tuple) else processed
         else:
@@ -199,8 +253,8 @@ class JsonPlusRedisSerializer(JsonPlusSerializer):
             return "null", b""
         else:
             try:
-                # Preprocess to add type markers to Interrupt objects
-                processed_obj = self._preprocess_interrupts(obj)
+                # Normalize marker types before JSON encoding.
+                processed_obj = self._preprocess_redis_json(obj)
                 # Try orjson first with custom default handler
                 json_bytes = orjson.dumps(processed_obj, default=self._default_handler)
                 return "json", json_bytes
@@ -318,10 +372,7 @@ class JsonPlusRedisSerializer(JsonPlusSerializer):
             # Match json.loads(object_hook=...) semantics by reviving children first.
             revived = {k: self._revive_if_needed(v) for k, v in obj.items()}
 
-            if (
-                revived.get("lc") in (1, 2)
-                and revived.get("type") == "constructor"
-            ):
+            if revived.get("lc") in (1, 2) and revived.get("type") == "constructor":
                 # If the dictionary is an lc constructor envelope
                 if revived.get("id") == ["builtins", "set"]:
                     return self._reconstruct_set_constructor(revived)
@@ -355,6 +406,22 @@ class JsonPlusRedisSerializer(JsonPlusSerializer):
                 except (ImportError, TypeError, ValueError) as e:
                     logger.debug(
                         "Failed to deserialize Interrupt object: %s", e, exc_info=True
+                    )
+
+            # _DeltaSnapshot marker (issue #201). Redis JSON cannot store msgpack
+            # ext code 7, so wrap the seed with a local constructor.
+            if (
+                revived.get("__delta_snapshot__") is True
+                and "value" in revived
+                and len(revived) == 2
+            ):
+                try:
+                    from langgraph.checkpoint.serde.types import _DeltaSnapshot
+
+                    return _DeltaSnapshot(revived["value"])
+                except (ImportError, TypeError, ValueError) as e:
+                    logger.debug(
+                        "Failed to deserialize _DeltaSnapshot: %s", e, exc_info=True
                     )
 
             # Check if this is a serialized Send object with type marker (issue #94)

--- a/tests/test_issue_201_delta_snapshot.py
+++ b/tests/test_issue_201_delta_snapshot.py
@@ -1,0 +1,226 @@
+"""Regression tests for issue #201: _DeltaSnapshot lost through Redis JSON.
+
+JsonPlusRedisSerializer used orjson and treated _DeltaSnapshot (a NamedTuple)
+as a plain tuple, so the snapshot seed became [[messages]]. DeltaChannel then
+failed with NotImplementedError: Message as a sequence must be (role string,
+template).
+"""
+
+import base64
+from collections.abc import Sequence
+from typing import Annotated, Any, TypedDict
+from unittest.mock import Mock
+from uuid import uuid4
+
+import orjson
+import pytest
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langgraph.channels.delta import DeltaChannel
+from langgraph.checkpoint.base import create_checkpoint, empty_checkpoint
+from langgraph.checkpoint.serde.types import _DeltaSnapshot
+from langgraph.graph import START, StateGraph
+from langgraph.graph.message import add_messages
+
+from langgraph.checkpoint.redis import RedisSaver
+from langgraph.checkpoint.redis.aio import AsyncRedisSaver
+from langgraph.checkpoint.redis.jsonplus_redis import JsonPlusRedisSerializer
+
+
+def _messages_delta_reducer(
+    state: list[BaseMessage], writes: Sequence[Any]
+) -> list[BaseMessage]:
+    result = state
+    for write in writes:
+        result = add_messages(result, write)
+    return result
+
+
+class _DeltaGraphState(TypedDict):
+    messages: Annotated[
+        list, DeltaChannel(_messages_delta_reducer, snapshot_frequency=2)
+    ]
+
+
+TURN_COUNT = 3
+
+
+def _chat_model(state: _DeltaGraphState) -> dict[str, list[AIMessage]]:
+    n = len(state["messages"])
+    return {"messages": [AIMessage(content=f"reply-{n}", id=f"ai-{n}")]}
+
+
+def _compile_delta_graph(checkpointer: Any) -> Any:
+    builder = StateGraph(_DeltaGraphState)
+    builder.add_node("chat", _chat_model)
+    builder.add_edge(START, "chat")
+    return builder.compile(checkpointer=checkpointer)
+
+
+def _turn_input(i: int) -> dict[str, list[HumanMessage]]:
+    return {"messages": [HumanMessage(content=f"turn-{i}", id=f"human-{i}")]}
+
+
+def _assert_stored_delta_snapshot(history: dict[str, Any]) -> None:
+    seed = history["messages"].get("seed")
+    assert isinstance(
+        seed, _DeltaSnapshot
+    ), f"DeltaChannel never wrote a _DeltaSnapshot seed, got {type(seed)}"
+
+
+def _expected_messages(turn_count: int) -> list[tuple[str, str, str]]:
+    expected = []
+    for i in range(turn_count):
+        expected.append(("human", f"human-{i}", f"turn-{i}"))
+
+        ai_index = len(expected)
+        expected.append(("ai", f"ai-{ai_index}", f"reply-{ai_index}"))
+    return expected
+
+
+def _assert_expected_messages(messages: list[BaseMessage], *, turn_count: int) -> None:
+    assert [(msg.type, msg.id, msg.content) for msg in messages] == (
+        _expected_messages(turn_count)
+    )
+
+
+def _dump_and_restore_messages_channel(value: Any) -> tuple[dict[str, Any], Any]:
+    saver = RedisSaver(redis_client=Mock())
+    checkpoint = create_checkpoint(
+        checkpoint=empty_checkpoint(),
+        channels={"messages": []},
+        step=1,
+    )
+    checkpoint["channel_values"]["messages"] = value
+
+    dumped = saver._dump_checkpoint(checkpoint)
+    restored = saver._deserialize_channel_values(dumped["channel_values"])["messages"]
+    return dumped, restored
+
+
+def test_delta_snapshot_roundtrip() -> None:
+    """Tests that nested _DeltaSnapshot values dump as a marker dict and load back.
+
+    Intended behavior: JsonPlusRedisSerializer should write
+    {"__delta_snapshot__": True, "value": ...} and revive that as _DeltaSnapshot
+    with HumanMessage contents, not as a nested list.
+    """
+    serializer = JsonPlusRedisSerializer()
+    original = {
+        "channel_values": {
+            "messages": _DeltaSnapshot([HumanMessage(content="hello", id="human-1")])
+        }
+    }
+
+    type_str, data_bytes = serializer.dumps_typed(original)
+    raw = orjson.loads(data_bytes)
+    result = serializer.loads_typed((type_str, data_bytes))
+
+    marker = raw["channel_values"]["messages"]
+    assert marker["__delta_snapshot__"] is True
+    assert set(marker) == {"__delta_snapshot__", "value"}
+
+    seed = result["channel_values"]["messages"]
+    assert isinstance(seed, _DeltaSnapshot)
+    assert isinstance(seed.value[0], HumanMessage)
+
+
+def test_plain_dict_not_snapshot() -> None:
+    """Tests that a plain {value: ...} dict is not treated as a _DeltaSnapshot.
+
+    Intended behavior: loads_typed should return a non-_DeltaSnapshot value when
+    the payload has a value field but no __delta_snapshot__ marker.
+    """
+    serializer = JsonPlusRedisSerializer()
+    payload = {"value": [HumanMessage(content="plain", id="human-plain")]}
+
+    type_str, data_bytes = serializer.dumps_typed(payload)
+    result = serializer.loads_typed((type_str, data_bytes))
+
+    assert not isinstance(result, _DeltaSnapshot)
+
+
+@pytest.mark.parametrize(
+    ("snapshot_value", "expected_value"),
+    [
+        pytest.param([b"payload"], [b"payload"], id="bytes"),
+        pytest.param([bytearray(b"payload")], [b"payload"], id="bytearray"),
+        pytest.param({1: "one"}, {"1": "one"}, id="non-string-key"),
+    ],
+)
+def test_msgpack_snapshot_roundtrip(snapshot_value: Any, expected_value: Any) -> None:
+    """Tests that msgpack fallback preserves _DeltaSnapshot.
+
+    Intended behavior: _DeltaSnapshot should restore as _DeltaSnapshot when
+    msgpack fallback is needed for Redis JSON-incompatible values.
+    """
+    dumped, restored = _dump_and_restore_messages_channel(
+        _DeltaSnapshot(snapshot_value)
+    )
+
+    assert dumped["type"] == "msgpack"
+    assert isinstance(restored, _DeltaSnapshot)
+    assert restored.value == expected_value
+
+
+def test_msgpack_tuple_not_snapshot() -> None:
+    """Tests that the msgpack normalization order does not over-match tuples.
+
+    Intended behavior: only real _DeltaSnapshot objects should get the
+    __delta_snapshot__ marker; plain tuples remain plain sequence values.
+    """
+    payload = b"payload"
+    dumped, restored = _dump_and_restore_messages_channel((payload,))
+    encoded = base64.b64encode(payload).decode()
+
+    assert dumped["type"] == "msgpack"
+    assert dumped["channel_values"]["messages"] == [{"__bytes__": encoded}]
+    assert not isinstance(restored, _DeltaSnapshot)
+    assert restored == [payload]
+
+
+def test_get_state_after_snapshot(redis_url: str) -> None:
+    """Tests that get_state works after DeltaChannel writes a snapshot.
+
+    Intended behavior: RedisSaver should reconstruct DeltaChannel state so
+    get_state returns BaseMessage instances instead of raising NotImplementedError.
+    """
+
+    thread_id = f"delta-graph-{uuid4()}"
+    config = {"configurable": {"thread_id": thread_id}}
+
+    with RedisSaver.from_conn_string(redis_url) as saver:
+        saver.setup()
+        graph = _compile_delta_graph(saver)
+
+        for i in range(TURN_COUNT):
+            graph.invoke(_turn_input(i), config)
+
+        state = graph.get_state(config)
+        _assert_expected_messages(state.values["messages"], turn_count=TURN_COUNT)
+        _assert_stored_delta_snapshot(
+            saver.get_delta_channel_history(config=config, channels=["messages"])
+        )
+
+
+async def test_aget_state_after_snapshot(redis_url: str) -> None:
+    """Tests that aget_state works after DeltaChannel writes a snapshot.
+
+    Intended behavior: AsyncRedisSaver should reconstruct DeltaChannel state so
+    aget_state returns BaseMessage instances instead of raising NotImplementedError.
+    """
+
+    thread_id = f"delta-graph-async-{uuid4()}"
+    config = {"configurable": {"thread_id": thread_id}}
+
+    async with AsyncRedisSaver.from_conn_string(redis_url) as saver:
+        await saver.asetup()
+        graph = _compile_delta_graph(saver)
+
+        for i in range(TURN_COUNT):
+            await graph.ainvoke(_turn_input(i), config)
+
+        state = await graph.aget_state(config)
+        _assert_expected_messages(state.values["messages"], turn_count=TURN_COUNT)
+        _assert_stored_delta_snapshot(
+            await saver.aget_delta_channel_history(config=config, channels=["messages"])
+        )


### PR DESCRIPTION
Fixes #201. 

## Summary

`_DeltaSnapshot` is implemented as a `NamedTuple`, so Redis JSON normalization previously treated it as a plain tuple/list. Snapshot seeds could be stored as nested arrays like `[[...]]` instead of preserving the `_DeltaSnapshot` type. During reconstruction, the seed then deserializes as a nested list since the `_DeltaSnapshot` type is now lost, causing `DeltaChannel` state reconstruction to fail.

With this fix, newly written `_DeltaSnapshot` values are prevented from losing type information. It does not automatically repair legacy snapshots that were already written as ambiguous nested arrays by older versions. Blindly unwrapping single-element arrays could corrupt legitimate user state, so any recovery for already-affected threads should be handled by an explicit, application-aware migration.

## Fixes

This PR adds an explicit JSON marker for `_DeltaSnapshot` to preserve the type during serialization and restores nested byte markers before reviving `_DeltaSnapshot`. Additionally, Redis JSON values are normalized in one order so semantic/type-carrying values are preserved before generic container handling.

## Tests

- Implemented regression coverage for `_DeltaSnapshot` JSON marker roundtrips and msgpack fallback cases involving binary values and non-string keys, and plain tuple values to ensure they are not mistaken for snapshots. 
- Implemented sync and async Redis integration tests that verify `DeltaChannel` state reconstructs with the expected message order after a stored snapshot.