### PR TITLE
fix(checkpoint): retry best-effort TTL application to prevent orphaned search index entries

### DIFF
--- a/langgraph/checkpoint/redis/__init__.py
+++ b/langgraph/checkpoint/redis/__init__.py
@@ -33,6 +33,7 @@ from langgraph.checkpoint.redis.base import (
     CHECKPOINT_WRITE_PREFIX,
     REDIS_KEY_SEPARATOR,
     BaseRedisSaver,
+    expire_with_retry,
 )
 from langgraph.checkpoint.redis.key_registry import SyncCheckpointKeyRegistry
 from langgraph.checkpoint.redis.message_exporter import (
@@ -583,13 +584,7 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
 
         # Apply TTL to latest pointer key as well (best-effort)
         if ttl_seconds is not None:
-            try:
-                self._redis.expire(latest_pointer_key, ttl_seconds)
-            except Exception:
-                logger.warning(
-                    "Failed to apply TTL to latest pointer key: %s",
-                    latest_pointer_key,
-                )
+            expire_with_retry(self._redis, latest_pointer_key, ttl_seconds)
 
         return next_config
 
@@ -684,12 +679,7 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
         if write_keys and self.ttl_config and "default_ttl" in self.ttl_config:
             ttl_seconds = int(self.ttl_config["default_ttl"] * 60)
             for key in write_keys:
-                try:
-                    self._redis.expire(key, ttl_seconds)
-                except Exception:
-                    logger.warning(
-                        "Failed to apply TTL to checkpoint write key: %s", key
-                    )
+                expire_with_retry(self._redis, key, ttl_seconds)
 
         # Update key registry with the write keys
         if self._key_registry and write_keys:
@@ -979,6 +969,16 @@ class RedisSaver(BaseRedisSaver[Union[Redis, RedisCluster], SearchIndex]):
                     write_keys = self._get_write_keys_from_search(
                         doc_thread_id, doc_checkpoint_ns, doc_checkpoint_id
                     )
+
+                # This checkpoint was resolved via the latest-checkpoint
+                # pointer (no explicit checkpoint_id given), so keep the
+                # pointer key's TTL in sync too - otherwise it can expire
+                # independently of the checkpoint/writes it points to.
+                if not checkpoint_id or checkpoint_id == EMPTY_ID_SENTINEL:
+                    latest_pointer_key = self._make_redis_checkpoint_latest_key(
+                        doc_thread_id, doc_checkpoint_ns
+                    )
+                    write_keys = [*write_keys, latest_pointer_key]
 
                 # Apply TTL to checkpoint and write keys
                 self._apply_ttl_to_keys(checkpoint_key, write_keys)

--- a/langgraph/checkpoint/redis/aio.py
+++ b/langgraph/checkpoint/redis/aio.py
@@ -46,6 +46,8 @@ from langgraph.checkpoint.redis.base import (
     CHECKPOINT_WRITE_PREFIX,
     REDIS_KEY_SEPARATOR,
     BaseRedisSaver,
+    aexpire_with_retry,
+    apersist_with_retry,
 )
 from langgraph.checkpoint.redis.key_registry import (
     AsyncCheckpointKeyRegistry as AsyncKeyRegistry,
@@ -318,29 +320,25 @@ class AsyncRedisSaver(
         if ttl_minutes is not None:
             # Special case: -1 means remove TTL (make persistent)
             if ttl_minutes == -1:
-                # Apply PERSIST individually per key so that a single failure
-                # does not prevent TTL removal on the remaining keys.
+                # Apply PERSIST individually per key (each retried on its
+                # own) so that a single failure does not prevent TTL
+                # removal on the remaining keys.
                 all_keys = [main_key] + (related_keys or [])
                 for key in all_keys:
-                    try:
-                        await self._redis.persist(key)
-                    except Exception:
-                        logger.warning("Failed to remove TTL from key: %s", key)
+                    await apersist_with_retry(self._redis, key)
 
                 return True
 
             # Regular TTL setting
             ttl_seconds = int(ttl_minutes * 60)
 
-            # Apply TTL individually per key so that a single EXPIRE failure
-            # (e.g. MOVED on Redis Enterprise proxy) does not prevent TTL
-            # from being set on the remaining keys.
+            # Apply TTL individually per key (each retried on its own) so
+            # that a single EXPIRE failure (e.g. MOVED on Redis Enterprise
+            # proxy) does not prevent TTL from being set on the remaining
+            # keys.
             all_keys = [main_key] + (related_keys or [])
             for key in all_keys:
-                try:
-                    await self._redis.expire(key, ttl_seconds)
-                except Exception:
-                    logger.warning("Failed to apply TTL to key: %s", key)
+                await aexpire_with_retry(self._redis, key, ttl_seconds)
 
             return True
 
@@ -483,6 +481,16 @@ class AsyncRedisSaver(
                     write_keys = await self._key_registry.get_write_keys(
                         doc_thread_id, doc_checkpoint_ns, doc_checkpoint_id
                     )
+
+                # This checkpoint was resolved via the latest-checkpoint
+                # pointer (no explicit checkpoint_id given), so keep the
+                # pointer key's TTL in sync too - otherwise it can expire
+                # independently of the checkpoint/writes it points to.
+                if not checkpoint_id or checkpoint_id == EMPTY_ID_SENTINEL:
+                    latest_pointer_key = self._make_redis_checkpoint_latest_key(
+                        doc_thread_id, doc_checkpoint_ns
+                    )
+                    write_keys = [*write_keys, latest_pointer_key]
 
                 # Apply TTL to checkpoint and write keys
                 await self._apply_ttl_to_keys(
@@ -1001,12 +1009,7 @@ class AsyncRedisSaver(
                 and ttl_seconds is not None
             ):
                 # In cluster mode, also call expire directly so tests can verify
-                try:
-                    await self._redis.expire(checkpoint_key, ttl_seconds)
-                except Exception:
-                    logger.warning(
-                        "Failed to apply TTL to checkpoint key: %s", checkpoint_key
-                    )
+                await aexpire_with_retry(self._redis, checkpoint_key, ttl_seconds)
 
             # Update latest checkpoint pointer
             latest_pointer_key = self._make_redis_checkpoint_latest_key(
@@ -1016,13 +1019,7 @@ class AsyncRedisSaver(
 
             # Apply TTL to latest pointer key as well (best-effort)
             if ttl_seconds is not None:
-                try:
-                    await self._redis.expire(latest_pointer_key, ttl_seconds)
-                except Exception:
-                    logger.warning(
-                        "Failed to apply TTL to latest pointer key: %s",
-                        latest_pointer_key,
-                    )
+                await aexpire_with_retry(self._redis, latest_pointer_key, ttl_seconds)
 
             return next_config
 
@@ -1192,14 +1189,7 @@ class AsyncRedisSaver(
                         # Apply TTL to registry key if configured (best-effort)
                         if self.ttl_config and "default_ttl" in self.ttl_config:
                             ttl_seconds = int(self.ttl_config.get("default_ttl") * 60)
-                            try:
-                                await self._redis.expire(zset_key, ttl_seconds)
-                            except Exception:
-                                logger.warning(
-                                    "Failed to apply TTL to write registry key: %s",
-                                    zset_key,
-                                    exc_info=True,
-                                )
+                            await aexpire_with_retry(self._redis, zset_key, ttl_seconds)
 
             else:
                 # For non-cluster mode, use pipeline without transaction to avoid lock contention.
@@ -1280,24 +1270,11 @@ class AsyncRedisSaver(
                 ):
                     ttl_seconds = int(self.ttl_config["default_ttl"] * 60)
                     for key in created_keys:
-                        try:
-                            await self._redis.expire(key, ttl_seconds)
-                        except Exception:
-                            logger.warning(
-                                "Failed to apply TTL to checkpoint write key: %s",
-                                key,
-                            )
+                        await aexpire_with_retry(self._redis, key, ttl_seconds)
 
                 if zset_key and self.ttl_config and "default_ttl" in self.ttl_config:
-                    try:
-                        ttl_seconds = int(self.ttl_config["default_ttl"] * 60)
-                        await self._redis.expire(zset_key, ttl_seconds)
-                    except Exception:
-                        logger.warning(
-                            "Failed to apply TTL to write registry key: %s",
-                            zset_key,
-                            exc_info=True,
-                        )
+                    ttl_seconds = int(self.ttl_config["default_ttl"] * 60)
+                    await aexpire_with_retry(self._redis, zset_key, ttl_seconds)
 
         except asyncio.CancelledError:
             # Handle cancellation/interruption

--- a/langgraph/checkpoint/redis/ashallow.py
+++ b/langgraph/checkpoint/redis/ashallow.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 import time
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -34,13 +33,12 @@ from langgraph.checkpoint.redis.base import (
     CHECKPOINT_WRITE_PREFIX,
     REDIS_KEY_SEPARATOR,
     BaseRedisSaver,
+    aexpire_with_retry,
 )
 from langgraph.checkpoint.redis.util import (
     to_storage_safe_id,
     to_storage_safe_str,
 )
-
-logger = logging.getLogger(__name__)
 
 # Constants
 MILLISECONDS_PER_SECOND = 1000
@@ -249,12 +247,7 @@ class AsyncShallowRedisSaver(BaseRedisSaver[AsyncRedis, AsyncSearchIndex]):
             # Apply TTL separately (best-effort)
             if self.ttl_config and "default_ttl" in self.ttl_config:
                 ttl_seconds = int(self.ttl_config.get("default_ttl") * 60)
-                try:
-                    await self._redis.expire(checkpoint_key, ttl_seconds)
-                except Exception:
-                    logger.warning(
-                        "Failed to apply TTL to checkpoint key: %s", checkpoint_key
-                    )
+                await aexpire_with_retry(self._redis, checkpoint_key, ttl_seconds)
 
             # NOTE: We intentionally do NOT clean up old writes here.
             # In the HITL (Human-in-the-Loop) flow, interrupt writes are saved via
@@ -395,12 +388,7 @@ class AsyncShallowRedisSaver(BaseRedisSaver[AsyncRedis, AsyncSearchIndex]):
         if self.ttl_config and self.ttl_config.get("refresh_on_read"):
             default_ttl_minutes = self.ttl_config.get("default_ttl", 60)
             ttl_seconds = int(default_ttl_minutes * 60)
-            try:
-                await self._redis.expire(checkpoint_key, ttl_seconds)
-            except Exception:
-                logger.warning(
-                    "Failed to refresh TTL on checkpoint key: %s", checkpoint_key
-                )
+            await aexpire_with_retry(self._redis, checkpoint_key, ttl_seconds)
 
         # Parse the checkpoint data
         checkpoint = full_checkpoint_data.get("checkpoint", {})
@@ -549,20 +537,8 @@ class AsyncShallowRedisSaver(BaseRedisSaver[AsyncRedis, AsyncSearchIndex]):
             if self.ttl_config and "default_ttl" in self.ttl_config:
                 ttl_seconds = int(self.ttl_config.get("default_ttl") * 60)
                 for key in write_keys:
-                    try:
-                        await self._redis.expire(key, ttl_seconds)
-                    except Exception:
-                        logger.warning(
-                            "Failed to apply TTL to checkpoint write key: %s", key
-                        )
-                try:
-                    await self._redis.expire(thread_zset_key, ttl_seconds)
-                except Exception:
-                    logger.warning(
-                        "Failed to apply TTL to write registry key: %s",
-                        thread_zset_key,
-                        exc_info=True,
-                    )
+                    await aexpire_with_retry(self._redis, key, ttl_seconds)
+                await aexpire_with_retry(self._redis, thread_zset_key, ttl_seconds)
 
         except asyncio.CancelledError:
             # Handle cancellation/interruption

--- a/langgraph/checkpoint/redis/base.py
+++ b/langgraph/checkpoint/redis/base.py
@@ -1,7 +1,9 @@
+import asyncio
 import base64
 import binascii
 import logging
 import random
+import time
 from abc import abstractmethod
 from typing import Any, Dict, Generic, List, Optional, Sequence, Tuple, Union, cast
 
@@ -33,6 +35,131 @@ logger = logging.getLogger(__name__)
 REDIS_KEY_SEPARATOR = ":"
 CHECKPOINT_PREFIX = "checkpoint"
 CHECKPOINT_WRITE_PREFIX = "checkpoint_write"
+
+# Bounded retry for best-effort TTL operations. A single transient failure
+# (e.g. a MOVED error from a Redis Enterprise proxy) must not permanently
+# leave a RediSearch-indexed key without a TTL, since that key would then
+# never expire and never leave the search index.
+_TTL_RETRY_ATTEMPTS = 3
+_TTL_RETRY_BASE_DELAY_SECONDS = 0.05
+
+
+def expire_with_retry(
+    redis_client: Any,
+    key: str,
+    ttl_seconds: int,
+    *,
+    attempts: int = _TTL_RETRY_ATTEMPTS,
+    base_delay: float = _TTL_RETRY_BASE_DELAY_SECONDS,
+) -> bool:
+    """Apply EXPIRE to a key, retrying transient failures.
+
+    Best-effort: never raises. Returns True if EXPIRE ultimately succeeded
+    (i.e. did not raise), False if every attempt raised.
+    """
+    last_exc: Optional[BaseException] = None
+    for attempt in range(attempts):
+        try:
+            redis_client.expire(key, ttl_seconds)
+            return True
+        except Exception as exc:
+            last_exc = exc
+            if attempt < attempts - 1:
+                time.sleep(base_delay * (2**attempt))
+    logger.warning(
+        "Failed to apply TTL to key %s after %d attempts: %s",
+        key,
+        attempts,
+        last_exc,
+        exc_info=last_exc,
+    )
+    return False
+
+
+def persist_with_retry(
+    redis_client: Any,
+    key: str,
+    *,
+    attempts: int = _TTL_RETRY_ATTEMPTS,
+    base_delay: float = _TTL_RETRY_BASE_DELAY_SECONDS,
+) -> bool:
+    """Apply PERSIST to a key, retrying transient failures.
+
+    Best-effort: never raises. Returns True if PERSIST ultimately succeeded
+    (i.e. did not raise), False if every attempt raised.
+    """
+    last_exc = None
+    for attempt in range(attempts):
+        try:
+            redis_client.persist(key)
+            return True
+        except Exception as exc:
+            last_exc = exc
+            if attempt < attempts - 1:
+                time.sleep(base_delay * (2**attempt))
+    logger.warning(
+        "Failed to remove TTL from key %s after %d attempts: %s",
+        key,
+        attempts,
+        last_exc,
+        exc_info=last_exc,
+    )
+    return False
+
+
+async def aexpire_with_retry(
+    redis_client: Any,
+    key: str,
+    ttl_seconds: int,
+    *,
+    attempts: int = _TTL_RETRY_ATTEMPTS,
+    base_delay: float = _TTL_RETRY_BASE_DELAY_SECONDS,
+) -> bool:
+    """Async version of expire_with_retry. Best-effort: never raises."""
+    last_exc: Optional[BaseException] = None
+    for attempt in range(attempts):
+        try:
+            await redis_client.expire(key, ttl_seconds)
+            return True
+        except Exception as exc:
+            last_exc = exc
+            if attempt < attempts - 1:
+                await asyncio.sleep(base_delay * (2**attempt))
+    logger.warning(
+        "Failed to apply TTL to key %s after %d attempts: %s",
+        key,
+        attempts,
+        last_exc,
+        exc_info=last_exc,
+    )
+    return False
+
+
+async def apersist_with_retry(
+    redis_client: Any,
+    key: str,
+    *,
+    attempts: int = _TTL_RETRY_ATTEMPTS,
+    base_delay: float = _TTL_RETRY_BASE_DELAY_SECONDS,
+) -> bool:
+    """Async version of persist_with_retry. Best-effort: never raises."""
+    last_exc = None
+    for attempt in range(attempts):
+        try:
+            await redis_client.persist(key)
+            return True
+        except Exception as exc:
+            last_exc = exc
+            if attempt < attempts - 1:
+                await asyncio.sleep(base_delay * (2**attempt))
+    logger.warning(
+        "Failed to remove TTL from key %s after %d attempts: %s",
+        key,
+        attempts,
+        last_exc,
+        exc_info=last_exc,
+    )
+    return False
 
 
 class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexType]):
@@ -249,29 +376,25 @@ class BaseRedisSaver(BaseCheckpointSaver[str], Generic[RedisClientType, IndexTyp
         if ttl_minutes is not None:
             # Special case: -1 means remove TTL (make persistent)
             if ttl_minutes == -1:
-                # Apply PERSIST individually per key so that a single failure
-                # does not prevent TTL removal on the remaining keys.
+                # Apply PERSIST individually per key (each retried on its own)
+                # so that a single failure does not prevent TTL removal on
+                # the remaining keys.
                 all_keys = [main_key] + (related_keys or [])
                 for key in all_keys:
-                    try:
-                        self._redis.persist(key)
-                    except Exception:
-                        logger.warning("Failed to remove TTL from key: %s", key)
+                    persist_with_retry(self._redis, key)
 
                 return True
 
             # Regular TTL setting
             ttl_seconds = int(ttl_minutes * 60)
 
-            # Apply TTL individually per key so that a single EXPIRE failure
-            # (e.g. MOVED on Redis Enterprise proxy) does not prevent TTL
-            # from being set on the remaining keys.
+            # Apply TTL individually per key (each retried on its own) so
+            # that a single EXPIRE failure (e.g. MOVED on Redis Enterprise
+            # proxy) does not prevent TTL from being set on the remaining
+            # keys.
             all_keys = [main_key] + (related_keys or [])
             for key in all_keys:
-                try:
-                    self._redis.expire(key, ttl_seconds)
-                except Exception:
-                    logger.warning("Failed to apply TTL to key: %s", key)
+                expire_with_retry(self._redis, key, ttl_seconds)
 
             return True
 

--- a/langgraph/checkpoint/redis/key_registry.py
+++ b/langgraph/checkpoint/redis/key_registry.py
@@ -4,7 +4,6 @@ This module provides a registry for tracking writes per checkpoint using Redis
 sorted sets, eliminating the need for some FT.SEARCH operations.
 """
 
-import logging
 from typing import List, Optional, Union
 
 from redis import Redis
@@ -12,9 +11,8 @@ from redis.asyncio import Redis as AsyncRedis
 from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
 from redis.cluster import RedisCluster
 
+from langgraph.checkpoint.redis.base import aexpire_with_retry, expire_with_retry
 from langgraph.checkpoint.redis.util import to_storage_safe_id, to_storage_safe_str
-
-logger = logging.getLogger(__name__)
 
 WRITE_KEYS_ZSET_PREFIX = "write_keys_zset"
 REDIS_KEY_SEPARATOR = ":"
@@ -176,14 +174,7 @@ class SyncCheckpointKeyRegistry(CheckpointKeyRegistry):
         zset_key = self.make_write_keys_zset_key(
             thread_id, checkpoint_ns, checkpoint_id
         )
-        try:
-            self._redis.expire(zset_key, ttl_seconds)
-        except Exception:
-            logger.warning(
-                "Failed to apply TTL to write registry key: %s",
-                zset_key,
-                exc_info=True,
-            )
+        expire_with_retry(self._redis, zset_key, ttl_seconds)
 
 
 class AsyncCheckpointKeyRegistry(CheckpointKeyRegistry):
@@ -278,11 +269,4 @@ class AsyncCheckpointKeyRegistry(CheckpointKeyRegistry):
         zset_key = self.make_write_keys_zset_key(
             thread_id, checkpoint_ns, checkpoint_id
         )
-        try:
-            await self._redis.expire(zset_key, ttl_seconds)
-        except Exception:
-            logger.warning(
-                "Failed to apply TTL to write registry key: %s",
-                zset_key,
-                exc_info=True,
-            )
+        await aexpire_with_retry(self._redis, zset_key, ttl_seconds)

--- a/langgraph/checkpoint/redis/shallow.py
+++ b/langgraph/checkpoint/redis/shallow.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import time
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -31,6 +30,7 @@ from langgraph.checkpoint.redis.base import (
     CHECKPOINT_WRITE_PREFIX,
     REDIS_KEY_SEPARATOR,
     BaseRedisSaver,
+    expire_with_retry,
 )
 from langgraph.checkpoint.redis.util import (
     from_storage_safe_str,
@@ -40,9 +40,6 @@ from langgraph.checkpoint.redis.util import (
 
 # Constants
 MILLISECONDS_PER_SECOND = 1000
-
-# Logger for this module
-logger = logging.getLogger(__name__)
 
 
 class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
@@ -198,12 +195,7 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
         # Apply TTL separately (best-effort)
         if self.ttl_config and "default_ttl" in self.ttl_config:
             ttl_seconds = int(self.ttl_config.get("default_ttl") * 60)
-            try:
-                self._redis.expire(checkpoint_key, ttl_seconds)
-            except Exception:
-                logger.warning(
-                    "Failed to apply TTL to checkpoint key: %s", checkpoint_key
-                )
+            expire_with_retry(self._redis, checkpoint_key, ttl_seconds)
 
         # NOTE: We intentionally do NOT clean up old writes here.
         # In the HITL (Human-in-the-Loop) flow, interrupt writes are saved via
@@ -364,12 +356,7 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
         if self.ttl_config and self.ttl_config.get("refresh_on_read"):
             default_ttl_minutes = self.ttl_config.get("default_ttl", 60)
             ttl_seconds = int(default_ttl_minutes * 60)
-            try:
-                self._redis.expire(checkpoint_key, ttl_seconds)
-            except Exception:
-                logger.warning(
-                    "Failed to refresh TTL on checkpoint key: %s", checkpoint_key
-                )
+            expire_with_retry(self._redis, checkpoint_key, ttl_seconds)
 
         # Parse the checkpoint data
         checkpoint = checkpoint_data.get("checkpoint", {})
@@ -526,23 +513,9 @@ class ShallowRedisSaver(BaseRedisSaver[Redis, SearchIndex]):
         # Apply TTL separately (best-effort — failures don't lose writes)
         if self.ttl_config and "default_ttl" in self.ttl_config:
             ttl_seconds = int(self.ttl_config.get("default_ttl") * 60)
-            try:
-                self._redis.expire(thread_write_registry_key, ttl_seconds)
-            except Exception:
-                logger.warning(
-                    "Failed to apply TTL to write registry key: %s",
-                    thread_write_registry_key,
-                    exc_info=True,
-                )
+            expire_with_retry(self._redis, thread_write_registry_key, ttl_seconds)
             for key in write_keys:
-                try:
-                    self._redis.expire(key, ttl_seconds)
-                except Exception:
-                    logger.warning(
-                        "Failed to apply TTL to checkpoint write key: %s",
-                        key,
-                        exc_info=True,
-                    )
+                expire_with_retry(self._redis, key, ttl_seconds)
 
     def _load_pending_writes(
         self, thread_id: str, checkpoint_ns: str, checkpoint_id: str

--- a/tests/test_ttl_apply_retry.py
+++ b/tests/test_ttl_apply_retry.py
@@ -1,0 +1,342 @@
+"""
+Regression tests for orphaned RediSearch index entries caused by best-effort
+TTL application.
+
+Root cause:
+`_apply_ttl_to_keys` (and the equivalent bespoke calls in key_registry.py,
+shallow.py, ashallow.py) applied EXPIRE to each checkpoint-related key
+individually, each wrapped in a single try/except that only logged a warning
+on failure (see PR #174). A single transient failure (e.g. a MOVED error on
+a Redis Enterprise proxy) permanently left that one key without a TTL. Since
+checkpoint and checkpoint_write documents are RediSearch-indexed JSON keys, a
+key that never got its TTL applied never expires and never leaves the search
+index — an orphaned index entry.
+
+These tests verify:
+1. A single transient EXPIRE failure no longer permanently strands a key
+   without a TTL (retry recovers it).
+2. After natural expiry, RediSearch has zero indexed entries left over for
+   the expired thread (the actual "leftover index" regression).
+3. The `checkpoint_latest:*` pointer key's TTL stays in sync with the
+   checkpoint it points to under `refresh_on_read`.
+"""
+
+import time
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from langgraph.checkpoint.base import create_checkpoint, empty_checkpoint
+from redis.exceptions import ResponseError
+from redisvl.query import FilterQuery
+from redisvl.query.filter import Tag
+
+from langgraph.checkpoint.redis import RedisSaver
+from langgraph.checkpoint.redis.aio import AsyncRedisSaver
+from langgraph.checkpoint.redis.base import aexpire_with_retry, expire_with_retry
+
+
+def _make_checkpoint() -> Any:
+    checkpoint = create_checkpoint(
+        checkpoint=empty_checkpoint(), channels={"messages": ["test"]}, step=1
+    )
+    checkpoint["channel_values"]["messages"] = ["test"]
+    return checkpoint
+
+
+def _flaky_once(real_method: Any) -> Any:
+    """Wrap a bound Redis method so its first call raises, subsequent calls pass through."""
+    calls = {"count": 0}
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise ResponseError("MOVED 12345 host:port")
+        return real_method(*args, **kwargs)
+
+    return wrapper
+
+
+def _aflaky_once(real_method: Any) -> Any:
+    calls = {"count": 0}
+
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise ResponseError("MOVED 12345 host:port")
+        return await real_method(*args, **kwargs)
+
+    return wrapper
+
+
+# ── Unit-level retry helper tests ───────────────────────────────────────────
+
+
+def test_expire_with_retry_recovers_from_one_transient_failure(
+    redis_url: str,
+) -> None:
+    """A single transient EXPIRE failure is retried and ultimately succeeds."""
+    from redis import Redis
+
+    client = Redis.from_url(redis_url)
+    try:
+        key = f"ttl-retry-test-{uuid4()}"
+        client.set(key, "value")
+
+        real_expire = client.expire
+        client.expire = _flaky_once(real_expire)  # type: ignore[method-assign]
+        try:
+            result = expire_with_retry(client, key, 60)
+        finally:
+            client.expire = real_expire  # type: ignore[method-assign]
+
+        assert result is True
+        ttl = client.ttl(key)
+        assert ttl > 0, f"Key should have a TTL after retry succeeded, got {ttl}"
+    finally:
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_aexpire_with_retry_recovers_from_one_transient_failure(
+    redis_url: str,
+) -> None:
+    """Async: a single transient EXPIRE failure is retried and ultimately succeeds."""
+    from redis.asyncio import Redis as AsyncRedis
+
+    client = AsyncRedis.from_url(redis_url)
+    try:
+        key = f"ttl-retry-test-async-{uuid4()}"
+        await client.set(key, "value")
+
+        real_expire = client.expire
+        client.expire = _aflaky_once(real_expire)  # type: ignore[method-assign]
+        try:
+            result = await aexpire_with_retry(client, key, 60)
+        finally:
+            client.expire = real_expire  # type: ignore[method-assign]
+
+        assert result is True
+        ttl = await client.ttl(key)
+        assert ttl > 0, f"Key should have a TTL after retry succeeded, got {ttl}"
+    finally:
+        await client.aclose()
+
+
+def test_expire_with_retry_gives_up_without_raising(redis_url: str) -> None:
+    """Best-effort contract: exhausted retries log and return False, never raise."""
+    from redis import Redis
+
+    client = Redis.from_url(redis_url)
+    try:
+        key = f"ttl-retry-exhausted-{uuid4()}"
+        client.set(key, "value")
+
+        def always_fails(*args: Any, **kwargs: Any) -> Any:
+            raise ResponseError("MOVED 12345 host:port")
+
+        real_expire = client.expire
+        client.expire = always_fails  # type: ignore[method-assign]
+        try:
+            result = expire_with_retry(client, key, 60, attempts=2, base_delay=0.01)
+        finally:
+            client.expire = real_expire  # type: ignore[method-assign]
+
+        assert result is False
+    finally:
+        client.close()
+
+
+# ── Integration: writes/checkpoints survive a transient EXPIRE failure ─────
+
+
+def test_write_key_gets_ttl_despite_one_transient_expire_failure(
+    redis_url: str,
+) -> None:
+    """
+    Reproduces the orphaned-index bug directly: before the fix, a single
+    failed EXPIRE permanently left a checkpoint_write key without a TTL,
+    so it never expired and never left the RediSearch index.
+    """
+    with RedisSaver.from_conn_string(redis_url, ttl={"default_ttl": 1}) as saver:
+        saver.setup()
+        thread_id = str(uuid4())
+        config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+        checkpoint = _make_checkpoint()
+
+        saved_config = saver.put(config, checkpoint, {"source": "test", "step": 1}, {})
+
+        real_expire = saver._redis.expire
+        saver._redis.expire = _flaky_once(real_expire)  # type: ignore[method-assign]
+        try:
+            saver.put_writes(saved_config, [("messages", "write-1")], "task-1")
+        finally:
+            saver._redis.expire = real_expire  # type: ignore[method-assign]
+
+        results = saver.checkpoint_writes_index.search(
+            FilterQuery(Tag("thread_id") == thread_id)
+        )
+        assert len(results.docs) > 0, "Write should have been created"
+        for doc in results.docs:
+            ttl = saver._redis.ttl(doc.id)
+            assert ttl > 0, (
+                f"Write key {doc.id} should have a TTL despite one transient "
+                f"EXPIRE failure — otherwise it never expires and lingers in "
+                f"the search index forever (got ttl={ttl})"
+            )
+
+
+@pytest.mark.asyncio
+async def test_async_write_key_gets_ttl_despite_one_transient_expire_failure(
+    redis_url: str,
+) -> None:
+    """Async counterpart of the write-key retry regression test."""
+    async with AsyncRedisSaver.from_conn_string(
+        redis_url, ttl={"default_ttl": 1}
+    ) as saver:
+        thread_id = str(uuid4())
+        config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+        checkpoint = _make_checkpoint()
+
+        saved_config = await saver.aput(
+            config, checkpoint, {"source": "test", "step": 1}, {}
+        )
+
+        real_expire = saver._redis.expire
+        saver._redis.expire = _aflaky_once(real_expire)  # type: ignore[method-assign]
+        try:
+            await saver.aput_writes(saved_config, [("messages", "write-1")], "task-1")
+        finally:
+            saver._redis.expire = real_expire  # type: ignore[method-assign]
+
+        results = await saver.checkpoint_writes_index.search(
+            FilterQuery(Tag("thread_id") == thread_id)
+        )
+        assert len(results.docs) > 0, "Write should have been created"
+        for doc in results.docs:
+            ttl = await saver._redis.ttl(doc.id)
+            assert ttl > 0, (
+                f"Write key {doc.id} should have a TTL despite one transient "
+                f"EXPIRE failure (got ttl={ttl})"
+            )
+
+
+# ── Integration: search index has no orphans after natural expiry ──────────
+
+
+def test_search_index_has_no_orphans_after_expiry(redis_url: str) -> None:
+    """
+    No existing test asserted FT.SEARCH state after expiry — only key
+    existence / get_tuple(). This closes that gap: once a checkpoint and
+    its writes naturally expire, both indexes must report zero hits.
+    """
+    with RedisSaver.from_conn_string(
+        redis_url, ttl={"default_ttl": 0.02}  # ~1 second
+    ) as saver:
+        saver.setup()
+        thread_id = str(uuid4())
+        config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+        checkpoint = _make_checkpoint()
+
+        saved_config = saver.put(config, checkpoint, {"source": "test", "step": 1}, {})
+        saver.put_writes(saved_config, [("messages", "write-1")], "task-1")
+
+        checkpoint_hits = saver.checkpoints_index.search(
+            FilterQuery(Tag("thread_id") == thread_id)
+        )
+        write_hits = saver.checkpoint_writes_index.search(
+            FilterQuery(Tag("thread_id") == thread_id)
+        )
+        assert len(checkpoint_hits.docs) > 0
+        assert len(write_hits.docs) > 0
+
+        time.sleep(3)
+
+        checkpoint_hits_after = saver.checkpoints_index.search(
+            FilterQuery(Tag("thread_id") == thread_id)
+        )
+        write_hits_after = saver.checkpoint_writes_index.search(
+            FilterQuery(Tag("thread_id") == thread_id)
+        )
+        assert len(checkpoint_hits_after.docs) == 0, (
+            "Checkpoint document should have left the search index after "
+            "expiry, but is still indexed"
+        )
+        assert len(write_hits_after.docs) == 0, (
+            "Write document(s) should have left the search index after "
+            "expiry, but are still indexed"
+        )
+
+
+# ── Integration: pointer key TTL stays in sync with the checkpoint ─────────
+
+
+def test_latest_pointer_ttl_refreshed_alongside_checkpoint(redis_url: str) -> None:
+    """
+    The checkpoint_latest:* pointer key must be refreshed alongside the
+    checkpoint it points to when refresh_on_read is enabled, otherwise it
+    can expire independently of the (still-alive) data it references.
+    """
+    with RedisSaver.from_conn_string(
+        redis_url, ttl={"default_ttl": 2, "refresh_on_read": True}
+    ) as saver:
+        saver.setup()
+        thread_id = str(uuid4())
+        checkpoint_ns = ""
+        config = {
+            "configurable": {"thread_id": thread_id, "checkpoint_ns": checkpoint_ns}
+        }
+        checkpoint = _make_checkpoint()
+
+        saver.put(config, checkpoint, {"source": "test", "step": 1}, {})
+
+        pointer_key = saver._make_redis_checkpoint_latest_key(thread_id, checkpoint_ns)
+        initial_pointer_ttl = saver._redis.ttl(pointer_key)
+        assert initial_pointer_ttl > 0
+
+        time.sleep(1.5)
+
+        # Read via the latest-checkpoint pointer (no explicit checkpoint_id).
+        result = saver.get_tuple(config)
+        assert result is not None
+
+        refreshed_pointer_ttl = saver._redis.ttl(pointer_key)
+        assert refreshed_pointer_ttl > initial_pointer_ttl - 1, (
+            "Pointer key TTL should be refreshed on read alongside the "
+            f"checkpoint it points to (initial={initial_pointer_ttl}, "
+            f"after read={refreshed_pointer_ttl})"
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_latest_pointer_ttl_refreshed_alongside_checkpoint(
+    redis_url: str,
+) -> None:
+    """Async counterpart of the pointer-TTL-sync regression test."""
+    async with AsyncRedisSaver.from_conn_string(
+        redis_url, ttl={"default_ttl": 2, "refresh_on_read": True}
+    ) as saver:
+        thread_id = str(uuid4())
+        checkpoint_ns = ""
+        config = {
+            "configurable": {"thread_id": thread_id, "checkpoint_ns": checkpoint_ns}
+        }
+        checkpoint = _make_checkpoint()
+
+        await saver.aput(config, checkpoint, {"source": "test", "step": 1}, {})
+
+        pointer_key = saver._make_redis_checkpoint_latest_key(thread_id, checkpoint_ns)
+        initial_pointer_ttl = await saver._redis.ttl(pointer_key)
+        assert initial_pointer_ttl > 0
+
+        time.sleep(1.5)
+
+        result = await saver.aget_tuple(config)
+        assert result is not None
+
+        refreshed_pointer_ttl = await saver._redis.ttl(pointer_key)
+        assert refreshed_pointer_ttl > initial_pointer_ttl - 1, (
+            "Pointer key TTL should be refreshed on read alongside the "
+            f"checkpoint it points to (initial={initial_pointer_ttl}, "
+            f"after read={refreshed_pointer_ttl})"
+        )


### PR DESCRIPTION
## Summary

When a checkpoint's TTL is applied, `_apply_ttl_to_keys` (and the equivalent calls in `key_registry.py`, `shallow.py`, `ashallow.py`) applies `EXPIRE`/`PERSIST` to each related key individually, each wrapped in its own `try/except` that only logs a warning on failure (this best-effort, per-key pattern was introduced deliberately in #174 to stop `EXPIRE` failures from aborting the write pipeline on Redis Enterprise proxy). A single transient failure on one key permanently leaves that key with **no TTL at all**. Since `checkpoint:*` and `checkpoint_write:*` are RediSearch-indexed JSON documents, a key that silently failed to get its TTL never expires and never leaves the search index — an orphaned index entry that persists indefinitely.

This PR adds bounded retry (3 attempts, capped exponential backoff) around every `EXPIRE`/`PERSIST` call so a transient failure no longer permanently strands a key, while preserving the existing best-effort, never-raise contract (TTL failures must never lose writes, per #174).

Also fixes a related gap: the `checkpoint_latest:*` pointer key had its TTL set once at write time but was never refreshed alongside the checkpoint it points to under `refresh_on_read`, so it could drift out of sync with the (still-alive) data it references.

## Root cause

```python
# base.py, _apply_ttl_to_keys (before)
for key in all_keys:
    try:
        self._redis.expire(key, ttl_seconds)
    except Exception:
        logger.warning("Failed to apply TTL to key: %s", key)
```

A transient error here (e.g. a `MOVED` response from an Enterprise proxy) means that key is *permanently* persistent — there is no second attempt, and nothing else ever revisits it.

Reproduced directly against `main`: forcing a single `EXPIRE` call to fail during `put_writes()` left the write key at `TTL -1` forever, and it kept showing up as a live `FT.SEARCH` hit indefinitely.

## Fix

Added `expire_with_retry` / `persist_with_retry` (sync) and `aexpire_with_retry` / `apersist_with_retry` (async) in `base.py`, each retrying up to 3 times with capped exponential backoff before giving up and logging (same as before, just with retry first). Swapped every bare `try/except` EXPIRE/PERSIST call over to these helpers:

- `base.py` / `aio.py`: `_apply_ttl_to_keys`
- `key_registry.py`: `apply_ttl` (sync + async)
- `shallow.py` / `ashallow.py`: the bespoke `expire()` calls (these don't go through `_apply_ttl_to_keys`)
- `__init__.py` / `aio.py`: the `checkpoint_latest:*` pointer key's initial TTL set, and its refresh is now included alongside the checkpoint + writes in the `refresh_on_read` path (it was previously omitted entirely)

No behavior/contract change beyond retrying before giving up: still best-effort, still never raises out of `put`/`put_writes`, still logs on final failure (now with attempt count).

## Tests

`tests/test_ttl_apply_retry.py` — real Redis via TestContainers, covering both sync and async savers:

- A single transient `EXPIRE` failure is retried and recovers (unit-level on the retry helpers, and end-to-end through `put_writes`)
- Exhausted retries still don't raise (preserves the #174 contract)
- **After natural expiry, `FT.SEARCH` returns zero hits for both the checkpoint and checkpoint-write indexes** — no existing test asserted index state after expiry (only key existence / `get_tuple()`), so this closes that gap directly
- `checkpoint_latest:*` pointer TTL stays in sync with the checkpoint under `refresh_on_read`

All new tests fail on `main` and pass with this fix. Ran the existing TTL suite (`test_ttl_synchronization.py`, `test_async_ttl_synchronization.py`, `test_ttl_removal.py`, `test_hitl_ttl_regression.py`, `test_checkpoint_ttl.py`, `test_base_client_info_and_ttl.py`, `test_async_shallow_checkpoint_write_ttl.py`, `test_shallow_ulid_ttl_cache.py`) alongside the new tests — 69/69 passing, no regressions. Also ran the broader `make test-all` suite up through checkpoint/store/cluster coverage with zero failures.
